### PR TITLE
Adding LongName and Fqdn to the Certificat (Subject Alternative Name)

### DIFF
--- a/clab/cert.go
+++ b/clab/cert.go
@@ -130,12 +130,16 @@ func (c *cLab) CreateCERT(shortDutName string) (err error) {
 			log.Fatalln(err)
 		}
 		type CERT struct {
-			Name   string
-			Prefix string
+			Name      string
+			LongName  string
+			Fqdn      string
+			Prefix    string
 		}
 		cert := CERT{
-			Name:   shortDutName,
-			Prefix: c.Conf.Prefix,
+			Name:     shortDutName,
+			LongName: node.LongName,
+			Fqdn:     node.Fqdn
+			Prefix:   c.Conf.Prefix,
 		}
 		f, err := os.Create(dst)
 		if err != nil {

--- a/templates/ca/csr.json
+++ b/templates/ca/csr.json
@@ -11,6 +11,9 @@
       "OU": "Container lab"
     }],
     "hosts": [
-      "{{.Name}}"
+      "{{.Name}}",
+      "{{.LongName}}",
+      "{{.Fqdn}}"
     ]
-  }
+}
+


### PR DESCRIPTION
The SAN prwviousely was just the shortname of the node. The hosts file which was created contained the LongName, which prevented establishing TLS sessions.
Now ShortName, LongName and Fqdn are all listed in the SAN attribute.