### PR TITLE
add timeout flag

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -1,6 +1,8 @@
 package clab
 
 import (
+	"time"
+
 	docker "github.com/docker/engine/client"
 )
 
@@ -14,7 +16,8 @@ type cLab struct {
 	DockerClient *docker.Client
 	Dir          *cLabDirectory
 
-	debug bool
+	debug   bool
+	timeout time.Duration
 }
 
 type cLabDirectory struct {
@@ -35,7 +38,8 @@ func NewContainerLab(d bool) *cLab {
 	}
 }
 
-func (c *cLab) Init() (err error) {
+func (c *cLab) Init(timeout time.Duration) (err error) {
 	c.DockerClient, err = docker.NewEnvClient()
+	c.timeout = timeout
 	return
 }

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -67,13 +66,13 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 
 	var bridgeName string
 	var netCreateResponse types.NetworkCreateResponse
-	nctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	netCreateResponse, err = c.DockerClient.NetworkCreate(nctx, c.Conf.DockerInfo.Bridge, networkOptions)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
 			log.Debugf("Container network %s already exists", c.Conf.DockerInfo.Bridge)
-			nctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			nctx, cancel := context.WithTimeout(ctx, c.timeout)
 			defer cancel()
 			netResource, err := c.DockerClient.NetworkInspect(nctx, c.Conf.DockerInfo.Bridge) //, types.NetworkInspectOptions{})
 			if err != nil {
@@ -132,7 +131,7 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 
 // DeleteBridge deletes a docker bridge
 func (c *cLab) DeleteBridge(ctx context.Context) (err error) {
-	nctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	err = c.DockerClient.NetworkRemove(nctx, c.Conf.DockerInfo.Bridge)
 	if err != nil {
@@ -145,7 +144,7 @@ func (c *cLab) DeleteBridge(ctx context.Context) (err error) {
 func (c *cLab) CreateContainer(ctx context.Context, shortDutName string, node *Node) (err error) {
 	log.Info("Create container:", shortDutName)
 
-	nctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	labels := map[string]string{
 		"containerlab":         "lab-" + c.Conf.Prefix,
@@ -199,7 +198,7 @@ func (c *cLab) CreateContainer(ctx context.Context, shortDutName string, node *N
 // StartContainer starts a docker container
 func (c *cLab) StartContainer(ctx context.Context, name string, node *Node) (err error) {
 	log.Debug("Start container: ", name)
-	nctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	err = c.DockerClient.ContainerStart(nctx,
 		node.Cid,
@@ -246,7 +245,7 @@ func (c *cLab) DeleteContainer(ctx context.Context, name string, node *Node) (er
 
 // InspectContainer inspects a docker container
 func (c *cLab) InspectContainer(ctx context.Context, id string, node *Node) (err error) {
-	nctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	s, err := c.DockerClient.ContainerInspect(nctx, id)
 	if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -26,7 +26,7 @@ var deployCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
-		err := c.Init()
+		err := c.Init(timeout)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -18,7 +18,7 @@ var destroyCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
-		err := c.Init()
+		err := c.Init(timeout)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -28,7 +28,7 @@ var execCmd = &cobra.Command{
 			return
 		}
 		c := clab.NewContainerLab(debug)
-		err := c.Init()
+		err := c.Init(timeout)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -13,7 +13,7 @@ var graphCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
-		err := c.Init()
+		err := c.Init(timeout)
 		if err != nil {
 			log.Info(err)
 		}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -37,7 +37,7 @@ var inspectCmd = &cobra.Command{
 			return
 		}
 		c := clab.NewContainerLab(debug)
-		err := c.Init()
+		err := c.Init(timeout)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -14,6 +15,7 @@ const (
 )
 
 var debug bool
+var timeout time.Duration
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -38,4 +40,5 @@ func Execute() {
 func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "enable debug mode")
+	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "", 30 *time.Second, "timeout for docker requests, e.g: 30s, 1m, 2m30s")
 }

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -19,7 +19,7 @@ var saveCmd = &cobra.Command{
 			return
 		}
 		c := clab.NewContainerLab(debug)
-		err := c.Init()
+		err := c.Init(timeout)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
add timeout flag to be used for docker requests needed for each command.
it defaults to 30 seconds, instead of the previous hardcoded 10 seconds
