### PR TITLE
Config cmd

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var infra bool
+var workload bool
+
+// configCmd represents the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "generate and apply configuration to the lab",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("config called")
+	},
+}
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "generate configuration for the lab",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("generate called")
+	},
+}
+
+// applyCmd represents the apply command
+var applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "apply the generated configuration on the lab nodes",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("apply called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(generateCmd)
+	configCmd.AddCommand(applyCmd)
+	//
+	generateCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
+	generateCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")
+	//
+	applyCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
+	applyCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -130,10 +130,8 @@ var deployCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
-	deployCmd.Flags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
 	deployCmd.Flags().BoolVarP(&graph, "graph", "g", false, "generate topology graph")
 	deployCmd.Flags().StringVarP(&bridge, "bridge", "b", "", "docker network name for management")
-	deployCmd.Flags().StringVarP(&prefix, "prefix", "p", "", "lab name prefix")
 	deployCmd.Flags().IPNetVarP(&ipv4Subnet, "ipv4-subnet", "4", net.IPNet{}, "management network IPv4 subnet range")
 	deployCmd.Flags().IPNetVarP(&ipv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
 }

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -84,6 +84,4 @@ var destroyCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(destroyCmd)
-	destroyCmd.Flags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
-	destroyCmd.Flags().StringVarP(&prefix, "prefix", "p", "", "lab name prefix")
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -71,7 +71,5 @@ var execCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(execCmd)
-	execCmd.Flags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
-	execCmd.Flags().StringVarP(&prefix, "prefix", "p", "", "lab name prefix")
 	execCmd.Flags().StringSliceVarP(&labels, "label", "", []string{}, "labels to filter container subset")
 }

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -35,5 +35,4 @@ var graphCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(graphCmd)
-	graphCmd.Flags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -127,8 +127,6 @@ var inspectCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(inspectCmd)
 
-	inspectCmd.Flags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
-	inspectCmd.Flags().StringVarP(&prefix, "prefix", "p", "", "lab name prefix")
 	inspectCmd.Flags().BoolVarP(&details, "details", "", false, "print all details of lab containers")
 	inspectCmd.Flags().StringVarP(&format, "format", "f", "", "lab name prefix")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,4 +38,6 @@ func Execute() {
 func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "enable debug mode")
+	rootCmd.PersistentFlags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
+	rootCmd.PersistentFlags().StringVarP(&prefix, "prefix", "p", "", "lab name prefix")
 }

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -70,6 +70,4 @@ var saveCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(saveCmd)
-	saveCmd.Flags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
-	saveCmd.Flags().StringVarP(&prefix, "prefix", "p", "", "lab name prefix")
 }


### PR DESCRIPTION
- added config command with 2 children commands ( generate and apply )
- change `--topo` and `--prefix` from local to persistent flags