### PR TITLE
added installation script and copied docs to containerlab.srlinux.dev

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker run -v $(pwd):/docs --entrypoint mkdocs squidfunk/mkdocs-material:5.5.12 gh-deploy --strict
+      - run: docker run -v $(pwd):/docs --entrypoint mkdocs squidfunk/mkdocs-material:5.5.12 gh-deploy --force --strict

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,4 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
-before:
-  hooks:
-    # You may remove this if you don't use go modules.
-    - go mod download
-    # you may remove this if you don't need go generate
-    - go generate ./...
+project_name: containerlab
 builds:
   - env:
       - CGO_ENABLED=0
@@ -13,15 +6,11 @@ builds:
       - -s -w -X github.com/srl-wim/container-lab/cmd.version={{.Version}} -X github.com/srl-wim/container-lab/cmd.commit={{.ShortCommit}} -X github.com/srl-wim/container-lab/cmd.date={{.Date}}
     goos:
       - linux
-      # - windows
       - darwin
 archives:
   - replacements:
       darwin: Darwin
       linux: Linux
-      #windows: Windows
-      #386: i386
-      #amd64: x86_64
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -32,8 +21,10 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
 nfpms:
   - id: "containerlab"
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     package_name: "containerlab"
     maintainer: "Wim Henderickx <wim.henderickx@nokia.com>"
     description: |
@@ -43,9 +34,7 @@ nfpms:
     formats:
       - rpm
       - deb
-    bindir: /usr/bin
-    files:
-      ./dist/container-lab_linux_amd64/container-lab: "/usr/local/bin/containerlab"
+    bindir: /usr/local/bin
     config_files:
       ./lab-examples/wan-topo.yml: "/etc/containerlab/lab-examples/wan-topo.yml"
       ./lab-examples/simple.yml: "/etc/containerlab/lab-examples/simple.yml"

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,12 +12,22 @@ var (
 	date    = "unknown"
 )
 
+var slug = `
+                           _                   _       _     
+                 _        (_)                 | |     | |    
+ ____ ___  ____ | |_  ____ _ ____   ____  ____| | ____| | _  
+/ ___) _ \|  _ \|  _)/ _  | |  _ \ / _  )/ ___) |/ _  | || \ 
+( (__| |_|| | | | |_( ( | | | | | ( (/ /| |   | ( ( | | |_) )
+\____)___/|_| |_|\___)_||_|_|_| |_|\____)_|   |_|\_||_|____/ 
+`
+
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "show containerlab version",
 
 	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(slug)
 		fmt.Printf("version : %s\n", version)
 		fmt.Printf(" commit : %s\n", commit)
 		fmt.Printf("   date : %s\n", date)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,26 @@
-`Containerlab` documentation portal is under construction...
+<p align=center><img src=https://gitlab.com/rdodin/pics/-/wikis/uploads/18b84497134ee39510d9daa6bc6712ad/containerlab_export.svg?sanitize=true/></p>
+
+[![github release](https://img.shields.io/github/release/srl-wim/container-lab.svg?style=flat-square&color=00c9ff&labelColor=bec8d2)](https://github.com/srl-wim/container-lab/releases/)
+[![Github all releases](https://img.shields.io/github/downloads/srl-wim/container-lab/total.svg?style=flat-square&color=00c9ff&labelColor=bec8d2)](https://github.com/srl-wim/container-lab/releases/)
+[![Go Report](https://img.shields.io/badge/go%20report-A%2B-blue?style=flat-square&color=00c9ff&labelColor=bec8d2)](https://goreportcard.com/report/github.com/srl-wim/container-lab)
+[![Doc](https://img.shields.io/badge/Docs-containerlab.srlinux.dev-blue?style=flat-square&color=00c9ff&labelColor=bec8d2)](https://containerlab.srlinux.dev)
+[![build](https://img.shields.io/github/workflow/status/srl-wim/container-lab/Test/master?style=flat-square&labelColor=bec8d2)](https://github.com/srl-wim/container-lab/releases/)
+
+---
+
+## Description
+
+Containerlab provides a framework for setting up and destroying labs for networking containers. It builds a virtual wiring using veth pairs between the containers to provide virtual topologies.
+
+The labs could also be wired to an external bridge to connect to external environment or to build hierarchical labs.
+
+A CA can be provided per lab and when enabled, containerlab generates certificates per device that can be used for various use cases, like GNMI, JSON RPC, etc.
+
+Lastly, containerlab also allows for a graphical output to validate the lab in a visual format using [graphviz](https://graphviz.org)
+
+Containerlab supports the following containers:
+
+* standard linux/alpine containers, typically used as test clients
+* networking containers:
+	* Nokia SR-Linux
+	* Arista cEOS.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,33 @@
+Containerlab is distributed as Linux package and can be installed on any Debian- or RHEL-like distributive.
+
+### Pre-requisites
+* Have `sudo` rights on the system: `containerlab` sets some parameters in the linux system to support the various options the containers need
+* [Install docker](https://docs.docker.com/engine/install/): this is used to manage the containers
+* Pull the container images which you intend to run to the Linux system
+
+### Package installation
+Containerlab package can be installed using the [installer script](https://github.com/srl-wim/container-lab/blob/master/get.sh) which detects the operating system type and installs the relevant package:
+
+```bash
+# download and install the latest release
+sudo curl -sL https://github.com/srl-wim/container-lab/raw/master/get.sh | \
+sudo bash
+
+# download a specific version - 0.6.0
+sudo curl -sL https://github.com/srl-wim/container-lab/raw/master/get.sh | \
+sudo bash -s -- -v 0.6.0
+```
+
+### Graphviz
+Containerlab's `graph` command can render a topology graph. For the generation of PNG images out of the topology files `graphviz` tool needs to be installed.
+
+If you don't want to install graphviz, just create the .dot file and use an [online graphviz tool](https://dreampuf.github.io/GraphvizOnline).
+```bash
+# Debian / Ubuntu
+sudo apt-get install graphviz
+
+# CentOS / Fedora / RedHat
+sudo yum install graphviz
+```
+
+Note, that `graphviz` installation is optional and is only required when a user wants to generate PNG files on the system out of the generated `dot` files.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,131 @@
+### Build a lab configuration file
+
+To help build the lab topologies a YAML file is used with the following parameters:
+
+* `Prefix`: The prefix can be seen as a namespace for the lab to make them unique.
+* `Docker_info`: we use docker to manage the various containers. In this section we specify the management bridge name and the IPV4 and IPV6 prefixes we use for connecting as an OOB management to the containers
+	* `bridge`
+	* `ipv4_subnet`
+	* `ipv6_subnet`
+* `Duts`: this section provides information with respect to the dut containers that are used in the lab. The dut configuration provides an inheritance to optimize the configuration in 3 levels: global_defaults, kind_defaults, dut_specifics.
+	*  	`global_defaults`: This section specifies the global defaults and will be inherited if the parameters are not specified in the more specific sections. As an example if kind = srl is specified in the global_defaults section and the kind is not specified in the kind_defaults or dut_specifics sections, the container will be using kind = srl
+		* `kind`: the kind of container e.g. srl, ceos, alpine, linux or bridge
+			* *bridge* is a special kind and is used to connect to an external bridge
+		* `group`: used in the graph output, to help visualize the output
+	* `kind_defaults`: This section specifies the kind defaults
+		* `type`: the type of container. e.g. to use 7220-dx, or 7220-ixr series
+		* `config`: the config file that is used by default for this kind of container
+		* `image`: the image that is used for this kind of container
+		* `license`: the license file that is used for this kind of container
+	* `dut_specifics`: This section specifies the dut specific details. If parameters are not set the can be inherited from higher sections.
+		* 	`kind`: the kind of container e.g. srl, ceos, alpine, linux or bridge
+		*  `group`: used in the graph output, to help visualize the output
+	* `kind_defaults`: This section specifies the kind defaults
+		* `<dutName>`
+			* `type`: the type of container. e.g. to use 7220-dx, or 7220-ixr series
+			* `config`: the config file that is used for this specific dut
+			* `image`: the image that is used for this specific dut
+			* `license`: the license file that is used for this specific dut
+* `Links`: Define the virtual wiring for the lab
+	* `endpoints`: define the virtual wire specified as: 
+	```
+	["<dutName-A>:<intf-dutName-A>", "<dutName-B>:<intf-dutName-B>"]
+	```
+
+There are some examples in the labs sub directory
+
+```
+Prefix: test
+Docker_info: 
+  bridge: srlinux_bridge
+  ipv4_subnet: "172.19.19.0/24"
+  ipv6_subnet: "2001:172:19:19::/80"
+
+Duts:
+  global_defaults:
+    kind: srl
+    group: bb
+  kind_defaults:
+    srl:
+      type: ixr6
+      config: templates/srl/config.json
+      image: srlinux:20.6.1-286
+      license: templates/srl/license.key
+    alpine:
+      image: henderiw/client-alpine:1.0.0
+  dut_specifics:
+    wan1: 
+    wan2: 
+
+Links:
+  - endpoints: ["wan1:e1-1", "wan2:e1-1"]
+```
+
+### Deploy the lab
+
+To deploy a lab there are a few parameters that can be used:
+
+```
+[henderiw@srlinux-2 clab]$ containerlab -h
+deploy container based lab environments with a user-defined interconnections
+
+Usage:
+  containerlab [command]
+
+Available Commands:
+  deploy      deploy a lab
+  destroy     destroy a lab
+  exec        execute a command on one or multiple containers
+  graph       generate a topology graph
+  help        Help about any command
+  save        save containers configuration
+  version     show containerlab version
+
+Flags:
+  -d, --debug   enable debug mode
+  -h, --help    help for containerlab
+
+Use "containerlab [command] --help" for more information about a command.
+```
+
+Example:
+
+```
+./containerlab deploy -t lab-examples/wan-topo.yml 
+```
+
+### Destroy the lab
+
+Example:
+
+```
+./containerlab destroy -t lab-examples/wan-topo.yml
+```
+
+### Generating a graph for the lab
+
+containerlab has the option to generate a topology graph based on [graphviz](https://graphviz.org), which can be utilized to generate a picture of the topology.
+
+```
+./containerlab graph -t lab-examples/wan-topo.yml
+```
+
+If graphviz is installed on your system (see pre-requisites), this will generate the graphviz .dot file as well as a final png file which can be viewed in any image viewer.
+If the graphviz executabe `dot` is not found on your system, just the `<topology_name>.dot` file is created which can then be transformed into an image via e.g. this website https://dreampuf.github.io/GraphvizOnline.
+
+
+### Logging in into the containers
+
+#### SRL
+
+```
+* ssh admin@<mgmt-ip-address>
+* docker exec -ti <container-name> sr_cli
+* docker exec -ti <container-name> /bin/bash
+```
+#### cEOS
+
+```
+* ssh admin@<mgmt-ip-address>
+* docker exec -ti <container-name> Cli
+```

--- a/get.sh
+++ b/get.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+
+# The install script is based off of the Apache 2.0 script from Helm,
+# https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+
+: ${BINARY_NAME:="containerlab"}
+: ${PROJECT_NAME:="containerlab"} # if project name does not match binary name
+: ${USE_SUDO:="true"}
+: ${USE_PKG:="true"} # default --use-pkg flag value. will use package installation by default unless the default is changed to false
+: ${VERIFY_CHECKSUM:="true"}
+: ${BIN_INSTALL_DIR:="/usr/local/bin"}
+: ${REPO_NAME:="srl-wim/container-lab"}
+: ${REPO_URL:="https://github.com/$REPO_NAME"}
+: ${PROJECT_URL:="https://containerlab.srlinux.dev"}
+
+# detectArch discovers the architecture for this system.
+detectArch() {
+    ARCH=$(uname -m)
+    case $ARCH in
+    # armv5*) ARCH="armv5" ;;
+    # armv6*) ARCH="armv6" ;;
+    # armv7*) ARCH="arm" ;;
+    # aarch64) ARCH="arm64" ;;
+    x86) ARCH="386" ;;
+    x86_64) ARCH="amd64" ;;
+    i686) ARCH="386" ;;
+    i386) ARCH="386" ;;
+    esac
+}
+
+# detectOS discovers the operating system for this system and its package format
+detectOS() {
+    OS=$(echo $(uname) | tr '[:upper:]' '[:lower:]')
+
+    case "$OS" in
+    # Minimalist GNU for Windows
+    mingw*) OS='windows' ;;
+    esac
+
+    if type "rpm" &>/dev/null; then
+        PKG_FORMAT="rpm"
+    elif type "dpkg" &>/dev/null; then
+        PKG_FORMAT="deb"
+    fi
+}
+
+# runs the given command as root (detects if we are root already)
+runAsRoot() {
+    local CMD="$*"
+
+    if [ $EUID -ne 0 -a $USE_SUDO = "true" ]; then
+        CMD="sudo $CMD"
+    fi
+
+    $CMD
+}
+
+# verifySupported checks that the os/arch combination is supported
+verifySupported() {
+    local supported="linux-amd64\nlinux-386"
+    if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
+        echo "No prebuilt binary for ${OS}-${ARCH}."
+        echo "To build from source, go to ${REPO_URL}"
+        exit 1
+    fi
+
+    if ! type "curl" &>/dev/null && ! type "wget" &>/dev/null; then
+        echo "Either curl or wget is required"
+        exit 1
+    fi
+}
+
+# verifyOpenssl checks if openssl is installed to perform checksum operation
+verifyOpenssl() {
+    if [ $VERIFY_CHECKSUM == "true" ]; then
+        if ! type "openssl" &>/dev/null; then
+            echo "openssl is not found. It is used to verify checksum of the downloaded archive.\nEither install openssl or provide '--skip-checksum' flag to the installer"
+            exit 1
+        fi
+    fi
+}
+
+# setDesiredVersion sets the desired version either to an explicit version provided by a user
+# or to the latest release available on github releases
+setDesiredVersion() {
+    if [ "x$DESIRED_VERSION" == "x" ]; then
+        # when desired version is not provided
+        # get latest tag from the gh releases
+        if type "curl" &>/dev/null; then
+            local latest_release_url=$(curl -s $REPO_URL/releases/latest | cut -d '"' -f 2)
+            TAG=$(echo $latest_release_url | cut -d '"' -f 2 | awk -F "/" '{print $NF}')
+            # tag with stripped `v` prefix
+            TAG_WO_VER=$(echo "${TAG}" | cut -c 2-)
+        elif type "wget" &>/dev/null; then
+            # get latest release info and get 5th line out of the response to get the URL
+            local latest_release_url=$(wget -q https://api.github.com/repos/$REPO_NAME/releases/latest -O- | sed '5q;d' | cut -d '"' -f 4)
+            TAG=$(echo $latest_release_url | cut -d '"' -f 2 | awk -F "/" '{print $NF}')
+            TAG_WO_VER=$(echo "${TAG}" | cut -c 2-)
+        fi
+    else
+        TAG=$DESIRED_VERSION
+        TAG_WO_VER=$(echo "${TAG}" | cut -c 2-)
+    fi
+}
+
+# checkInstalledVersion checks which version is installed and
+# if it needs to be changed.
+checkInstalledVersion() {
+    if [[ -f "${BIN_INSTALL_DIR}/${BINARY_NAME}" ]]; then
+        local version=$("${BIN_INSTALL_DIR}/${BINARY_NAME}" version | head -1 | awk '{print $NF}')
+        if [[ "v$version" == "$TAG" ]]; then
+            echo "${BINARY_NAME} is already at ${DESIRED_VERSION:-latest ($version)}" version
+            return 0
+        else
+            echo "${BINARY_NAME} ${TAG_WO_VER} is available. Changing from version ${version}."
+            return 1
+        fi
+    else
+        return 1
+    fi
+}
+
+# createTempDir creates temporary directory where we downloaded files
+createTempDir() {
+    TMP_ROOT="$(mktemp -d)"
+    TMP_BIN="$TMP_ROOT/$BINARY_NAME"
+}
+
+# downloadFile downloads the latest binary archive, the checksum file and performs the sum check
+downloadFile() {
+    EXT="tar.gz" # download file extension
+    if [ $USE_PKG == "true" ]; then
+        EXT=$PKG_FORMAT
+    fi
+    ARCHIVE="${PROJECT_NAME}_${TAG_WO_VER}_${OS}_${ARCH}.${EXT}"
+    DOWNLOAD_URL="${REPO_URL}/releases/download/${TAG}/${ARCHIVE}"
+    CHECKSUM_URL="${REPO_URL}/releases/download/${TAG}/checksums.txt"
+    TMP_FILE="$TMP_ROOT/$ARCHIVE"
+    SUM_FILE="$TMP_ROOT/checksums.txt"
+    echo "Downloading $DOWNLOAD_URL"
+    if type "curl" &>/dev/null; then
+        curl -SsL "$CHECKSUM_URL" -o "$SUM_FILE"
+        curl -SsL "$DOWNLOAD_URL" -o "$TMP_FILE"
+    elif type "wget" &>/dev/null; then
+        wget -q -O "$SUM_FILE" "$CHECKSUM_URL"
+        wget -q -O "$TMP_FILE" "$DOWNLOAD_URL"
+    fi
+
+    # verify downloaded file
+    if [ $VERIFY_CHECKSUM == "true" ]; then
+        local sum=$(openssl sha1 -sha256 ${TMP_FILE} | awk '{print $2}')
+        local expected_sum=$(cat ${SUM_FILE} | grep -i $ARCHIVE | awk '{print $1}')
+        if [ "$sum" != "$expected_sum" ]; then
+            echo "SHA sum of ${TMP_FILE} does not match. Aborting."
+            exit 1
+        fi
+        echo "Checksum verified"
+    fi
+}
+
+# installFile verifies the SHA256 for the file, then unpacks and
+# installs it. By default, the installation is done from .tar.gz archive, that can be overriden with --use-pkg flag
+installFile() {
+    tar xf "$TMP_FILE" -C "$TMP_ROOT"
+    echo "Preparing to install $BINARY_NAME ${TAG_WO_VER} into ${BIN_INSTALL_DIR}"
+    runAsRoot cp "$TMP_ROOT/$BINARY_NAME" "$BIN_INSTALL_DIR/$BINARY_NAME"
+    echo "$BINARY_NAME installed into $BIN_INSTALL_DIR/$BINARY_NAME"
+}
+
+# installPkg installs the downloaded version of a package in a deb or rpm format
+installPkg() {
+    echo "Preparing to install $BINARY_NAME ${TAG_WO_VER} from package"
+    if [ $PKG_FORMAT == "deb" ]; then
+        runAsRoot dpkg -i $TMP_FILE
+    elif [ $PKG_FORMAT == "rpm" ]; then
+        runAsRoot rpm -i $TMP_FILE
+    fi
+}
+
+# fail_trap is executed if an error occurs.
+fail_trap() {
+    result=$?
+    if [ "$result" != "0" ]; then
+        if [[ -n "$INPUT_ARGUMENTS" ]]; then
+            echo "Failed to install $BINARY_NAME with the arguments provided: $INPUT_ARGUMENTS"
+            help
+        else
+            echo "Failed to install $BINARY_NAME"
+        fi
+        echo -e "\tFor support, go to $REPO_URL/issues"
+    fi
+    cleanup
+    exit $result
+}
+
+# testVersion tests the installed client to make sure it is working.
+testVersion() {
+    set +e
+    $BIN_INSTALL_DIR/$BINARY_NAME version
+    if [ "$?" = "1" ]; then
+        echo "$BINARY_NAME not found. Is $BIN_INSTALL_DIR in your "'$PATH?'
+        exit 1
+    fi
+    set -e
+}
+
+# help provides possible cli installation arguments
+help() {
+    echo "Accepted cli arguments are:"
+    echo -e "\t[--help|-h ] ->> prints this help"
+    echo -e "\t[--version|-v <desired_version>] . When not defined it fetches the latest release from GitHub"
+    echo -e "\te.g. --version v0.1.1"
+    echo -e "\t[--use-pkg]  ->> install from deb/rpm packages"
+    echo -e "\t[--no-sudo]  ->> install without sudo"
+    echo -e "\t[--skip-checksum]  ->> disable automatic checksum verification"
+}
+
+# removes temporary directory used to download artefacts
+cleanup() {
+    if [[ -d "${TMP_ROOT:-}" ]]; then
+        rm -rf "$TMP_ROOT"
+    fi
+}
+
+# Execution
+
+#Stop execution on any error
+trap "fail_trap" EXIT
+set -e
+
+# Parsing input arguments (if any)
+export INPUT_ARGUMENTS="${@}"
+set -u
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    '--version' | -v)
+        shift
+        if [[ $# -ne 0 ]]; then
+            export DESIRED_VERSION="v${1}"
+        else
+            echo -e "Please provide the desired version. e.g. --version 0.1.1"
+            exit 0
+        fi
+        ;;
+    '--no-sudo')
+        USE_SUDO="false"
+        ;;
+    '--skip-checksum')
+        VERIFY_CHECKSUM="false"
+        ;;
+    '--use-pkg')
+        USE_PKG="true"
+        ;;
+    '--help' | -h)
+        help
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+    esac
+    shift
+done
+set +u
+
+detectArch
+detectOS
+verifySupported
+setDesiredVersion
+if ! checkInstalledVersion; then
+    createTempDir
+    verifyOpenssl
+    downloadFile
+    if [ $USE_PKG == "true" ]; then
+        installPkg
+    else
+        installFile
+    fi
+    testVersion
+    cleanup
+fi

--- a/get.sh
+++ b/get.sh
@@ -7,7 +7,7 @@
 : ${PROJECT_NAME:="containerlab"} # if project name does not match binary name
 : ${USE_SUDO:="true"}
 : ${USE_PKG:="true"} # default --use-pkg flag value. will use package installation by default unless the default is changed to false
-: ${VERIFY_CHECKSUM:="true"}
+: ${VERIFY_CHECKSUM:="false"}
 : ${BIN_INSTALL_DIR:="/usr/local/bin"}
 : ${REPO_NAME:="srl-wim/container-lab"}
 : ${REPO_URL:="https://github.com/$REPO_NAME"}
@@ -74,7 +74,7 @@ verifySupported() {
 verifyOpenssl() {
     if [ $VERIFY_CHECKSUM == "true" ]; then
         if ! type "openssl" &>/dev/null; then
-            echo "openssl is not found. It is used to verify checksum of the downloaded archive.\nEither install openssl or provide '--skip-checksum' flag to the installer"
+            echo "openssl is not found. It is used to verify checksum of the downloaded file."
             exit 1
         fi
     fi
@@ -212,7 +212,7 @@ help() {
     echo -e "\te.g. --version v0.1.1"
     echo -e "\t[--use-pkg]  ->> install from deb/rpm packages"
     echo -e "\t[--no-sudo]  ->> install without sudo"
-    echo -e "\t[--skip-checksum]  ->> disable automatic checksum verification"
+    echo -e "\t[--verify-checksum]  ->> verify checksum of the downloaded file"
 }
 
 # removes temporary directory used to download artefacts
@@ -245,8 +245,8 @@ while [[ $# -gt 0 ]]; do
     '--no-sudo')
         USE_SUDO="false"
         ;;
-    '--skip-checksum')
-        VERIFY_CHECKSUM="false"
+    '--verify-checksum')
+        VERIFY_CHECKSUM="true"
         ;;
     '--use-pkg')
         USE_PKG="true"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
 site_name: containerlab
 nav:
   - Home: index.md
+  - Installation: install.md
+  - Usage: usage.md
 
 site_author: Roman Dodin
 site_description: >-


### PR DESCRIPTION
This PR adds the following functionality:

1. Adds `project_name` directive to goreleaser, so that the binary name inside the package will be `containerlab` instead of `container-lab`. This unifies the binary name.

2. adds an automatic installer script which simplifies containerlab installation. The script automatically detect the OS/Arch type and package manager. Then it will download the latest release automatically and install it with the package manager available on the system.

    After merging this PR and issuing the next tagged release, the installation will be as easy as

    ```bash
    sudo curl -sL https://github.com/srl-wim/container-lab/raw/master/get.sh | \
    sudo bash
   ```

3. The documentation has been copied from README.md to the relevant files under the `docs` directory. Once merged, the documentation will appear at containerlab.srlinux.dev documentation site.
    IMHO It is better if we write documentation inside the `docs` as it simplifies the doc consumption.
    You can locally checkout this branch and test how the docs look like by running the mkdocs engine from the repo folder:
    ```
     docker run --rm -it -p 8000:8000 -v $(pwd):/docs squidfunk/mkdocs-material:5.5.12
    ```