### PR TITLE
add check for endpoint name length

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -427,6 +427,8 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 	} else {
 		endpoint.EndpointName = split[1]
 	}
-
+	if len(endpoint.EndpointName) > 16 {
+		log.Fatalf("interface '%s' name too long > 16", endpoint.EndpointName)
+	}
 	return endpoint
 }

--- a/clab/config.go
+++ b/clab/config.go
@@ -427,8 +427,8 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 	} else {
 		endpoint.EndpointName = split[1]
 	}
-	if len(endpoint.EndpointName) > 16 {
-		log.Fatalf("interface '%s' name too long > 16", endpoint.EndpointName)
+	if len(endpoint.EndpointName) > 15 {
+		log.Fatalf("interface '%s' name too long > 15", endpoint.EndpointName)
 	}
 	return endpoint
 }


### PR DESCRIPTION
Added a check for endpoint name length, max interface length is 15 bytes.
This PR makes it fail if the name is too long.
We can consider a better fix in the future, like randomly generated interfaces names