### PR TITLE
added upgrade functionality

### DIFF
--- a/cmd/verUpgrade.go
+++ b/cmd/verUpgrade.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var downloadURL = "https://github.com/srl-wim/container-lab/raw/master/get.sh"
+
+// upgradeCmd represents the version command
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "upgrade containerlab to latest available version",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		f, err := ioutil.TempFile("", "containerlab")
+		defer os.Remove(f.Name())
+		if err != nil {
+			log.Fatalf("Failed to create temp file %s\n", err)
+		}
+		downloadFile(downloadURL, f)
+
+		c := exec.Command("bash", f.Name())
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+		err = c.Run()
+		if err != nil {
+			log.Fatalf("Upgrade failed: %s\n", err)
+		}
+	},
+}
+
+// downloadFile will download a file from a URL and write its content to a file
+func downloadFile(url string, file *os.File) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Write the body to file
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func init() {
+	versionCmd.AddCommand(upgradeCmd)
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -24,7 +24,7 @@ var slug = `
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "show containerlab version",
+	Short: "show containerlab version or upgrade",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(slug)

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,3 +31,12 @@ sudo yum install graphviz
 ```
 
 Note, that `graphviz` installation is optional and is only required when a user wants to generate PNG files on the system out of the generated `dot` files.
+
+### Upgrade
+To upgrade `containerlab` to the latest available version issue the following command:
+
+```
+containerlab version upgrade
+```
+
+This command will fetch the installation script and will upgrade the tool to its most recent version.


### PR DESCRIPTION
With this PR we add `containerlab version upgrade` subcommand that takes another step to simplify version management for our users.

This command will fetch the installation script and call it; the script will upgrade containerlab to its most recent version.