### PR TITLE
deploy and destroy command aliases

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -23,7 +23,7 @@ var ipv6Subnet net.IPNet
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "deploy a lab",
-
+	Aliases: []string{"dep"},
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
 		err := c.Init(timeout)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -15,7 +15,7 @@ import (
 var destroyCmd = &cobra.Command{
 	Use:   "destroy",
 	Short: "destroy a lab",
-
+	Aliases: []string{"des"},
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
 		err := c.Init(timeout)


### PR DESCRIPTION
added command aliases, I keep misspelling `destroy`...