### PR TITLE
add concurrency for generating certificates and wiring

### DIFF
--- a/clab/cert.go
+++ b/clab/cert.go
@@ -72,7 +72,13 @@ func (c *cLab) GenerateRootCa(csrRootJsonTpl *template.Template, input CaRootInp
 	return certs, nil
 }
 
-func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Template, input CertInput) (*certificates, error) {
+func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Template, node *Node) (*certificates, error) {
+	input := CertInput{
+		Name:     node.ShortName,
+		LongName: node.LongName,
+		Fqdn:     node.Fqdn,
+		Prefix:   c.Conf.Prefix,
+	}
 	CreateDirectory(path.Join(c.Dir.LabCA, input.Name), 0755)
 	var err error
 	csrBuff := new(bytes.Buffer)

--- a/clab/cert.go
+++ b/clab/cert.go
@@ -123,13 +123,6 @@ func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Templa
 	if len(signReq.Hosts) == 0 && len(req.Hosts) == 0 {
 		log.Warning(generator.CSRNoHostMessage)
 	}
-	//
-	c.m.Lock()
-	if node, ok := c.Nodes[input.Name]; ok {
-		node.TLSCert = string(cert)
-		node.TLSKey = string(key)
-	}
-	c.m.Unlock()
 	certs := &certificates{
 		Key:  key,
 		Csr:  csrBytes,

--- a/clab/cert.go
+++ b/clab/cert.go
@@ -73,6 +73,8 @@ func (c *cLab) GenerateRootCa(csrRootJsonTpl *template.Template, input CaRootInp
 }
 
 func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Template, node *Node) (*certificates, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	input := CertInput{
 		Name:     node.ShortName,
 		LongName: node.LongName,
@@ -87,17 +89,17 @@ func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Templa
 		return nil, err
 	}
 
-	req := csr.CertificateRequest{
+	req := &csr.CertificateRequest{
 		KeyRequest: csr.NewKeyRequest(),
 	}
-	err = json.Unmarshal(csrBuff.Bytes(), &req)
+	err = json.Unmarshal(csrBuff.Bytes(), req)
 	if err != nil {
 		return nil, err
 	}
 
 	var key, csrBytes []byte
 	gen := &csr.Generator{Validator: genkey.Validator}
-	csrBytes, key, err = gen.ProcessRequest(&req)
+	csrBytes, key, err = gen.ProcessRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -1,6 +1,7 @@
 package clab
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 type cLab struct {
 	Conf         *Conf
 	FileInfo     *File
-	m            *sync.Mutex
+	m            *sync.RWMutex
 	Nodes        map[string]*Node
 	Links        map[int]*Link
 	DockerClient *docker.Client
@@ -34,7 +35,7 @@ func NewContainerLab(d bool) *cLab {
 	return &cLab{
 		Conf:     new(Conf),
 		FileInfo: new(File),
-		m:        new(sync.Mutex),
+		m:        new(sync.RWMutex),
 		Nodes:    make(map[string]*Node),
 		Links:    make(map[int]*Link),
 		debug:    d,
@@ -45,4 +46,16 @@ func (c *cLab) Init(timeout time.Duration) (err error) {
 	c.DockerClient, err = docker.NewEnvClient()
 	c.timeout = timeout
 	return
+}
+
+func (c *cLab) CreateNode(ctx context.Context, node *Node, certs *certificates) error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	node.TLSCert = string(certs.Cert)
+	node.TLSKey = string(certs.Key)
+	err := c.CreateNodeDirStructure(node)
+	if err != nil {
+		return err
+	}
+	return c.CreateContainer(ctx, node)
 }

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -1,6 +1,7 @@
 package clab
 
 import (
+	"sync"
 	"time"
 
 	docker "github.com/docker/engine/client"
@@ -11,6 +12,7 @@ import (
 type cLab struct {
 	Conf         *Conf
 	FileInfo     *File
+	m            *sync.Mutex
 	Nodes        map[string]*Node
 	Links        map[int]*Link
 	DockerClient *docker.Client
@@ -32,6 +34,7 @@ func NewContainerLab(d bool) *cLab {
 	return &cLab{
 		Conf:     new(Conf),
 		FileInfo: new(File),
+		m:        new(sync.Mutex),
 		Nodes:    make(map[string]*Node),
 		Links:    make(map[int]*Link),
 		debug:    d,

--- a/clab/config.go
+++ b/clab/config.go
@@ -65,11 +65,11 @@ type volume struct {
 
 // Node is a struct that contains the information of a container element
 type Node struct {
-	ShortName  string
-	LongName   string
-	Fqdn       string
-	LabDir     string
-	CertDir    string
+	ShortName string
+	LongName  string
+	Fqdn      string
+	LabDir    string
+	// CertDir    string
 	Index      int
 	Group      string
 	Kind       string
@@ -247,7 +247,7 @@ func (c *cLab) NewNode(dutName string, dut dutInfo, idx int) {
 	node.LongName = "containerlab" + "-" + c.Conf.Prefix + "-" + dutName
 	node.Fqdn = dutName + "." + c.Conf.Prefix + ".io"
 	node.LabDir = c.Dir.Lab + "/" + dutName
-	node.CertDir = c.Dir.LabCA + "/" + dutName
+	// node.CertDir = c.Dir.LabCA + "/" + dutName
 	node.Index = idx
 
 	// initialize the node with global parameters

--- a/clab/config.go
+++ b/clab/config.go
@@ -69,7 +69,6 @@ type Node struct {
 	LongName  string
 	Fqdn      string
 	LabDir    string
-	// CertDir    string
 	Index      int
 	Group      string
 	Kind       string
@@ -79,10 +78,7 @@ type Node struct {
 	License    string
 	Image      string
 	Topology   string
-	Path       string
 	EnvConf    string
-	TLS        string
-	Checkpoint string
 	Sysctls    map[string]string
 	User       string
 	Cmd        string
@@ -95,7 +91,6 @@ type Node struct {
 	MgmtIPv4   string
 	MgmtIPv6   string
 	MgmtMac    string
-	AS         uint32
 
 	TLSCert   string
 	TLSKey    string

--- a/clab/file.go
+++ b/clab/file.go
@@ -146,17 +146,17 @@ func CreateDirectory(path string, perm os.FileMode) {
 func (c *cLab) CreateNodeDirStructure(node *Node, shortDutName string) (err error) {
 	switch node.Kind {
 	case "srl":
-		log.Info("Create directory structure for SRL container:", shortDutName)
+		log.Infof("Create directory structure for SRL container: %s", shortDutName)
 		var src string
 		var dst string
 		// copy license file to node specific directory in lab
 		src = node.License
 		dst = path.Join(c.Dir.Lab, "license.key")
 		if err = copyFile(src, dst); err != nil {
-			log.Error(fmt.Sprintf("CopyFile src %s -> dat %s failed %q\n", src, dst, err))
+			log.Errorf("CopyFile src %s -> dst %s failed %q\n", src, dst, err)
 			return err
 		}
-		log.Debug(fmt.Sprintf("CopyFile src %s -> dat %s succeeded\n", src, dst))
+		log.Debugf("CopyFile src %s -> dst %s succeeded", src, dst)
 
 		// create dut directory in lab
 		CreateDirectory(node.LabDir, 0777)
@@ -200,15 +200,8 @@ func (c *cLab) CreateNodeDirStructure(node *Node, shortDutName string) (err erro
 			if err != nil {
 				log.Errorf("node=%s, failed to generate config: %v", node.ShortName, err)
 			}
-			//src = node.Config
-			// err = copyFile(src, dst)
-			// if err != nil {
-			// 	log.Error(fmt.Sprintf("CopyFile src %s -> dat %s failed %q\n", src, dst, err))
-			// 	return err
-			// }
-			// log.Debug(fmt.Sprintf("CopyFile src %s -> dat %s succeeded\n", src, dst))
 		} else {
-			log.Debug("Config File Exists")
+			log.Debugf("Config File Exists for node %s", node.ShortName)
 		}
 		node.Config = dst
 

--- a/clab/file.go
+++ b/clab/file.go
@@ -143,10 +143,10 @@ func CreateDirectory(path string, perm os.FileMode) {
 }
 
 // CreateNodeDirStructure create the directory structure and files for the clab
-func (c *cLab) CreateNodeDirStructure(node *Node, shortDutName string) (err error) {
+func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 	switch node.Kind {
 	case "srl":
-		log.Infof("Create directory structure for SRL container: %s", shortDutName)
+		log.Infof("Create directory structure for SRL container: %s", node.ShortName)
 		var src string
 		var dst string
 		// copy license file to node specific directory in lab

--- a/clab/file.go
+++ b/clab/file.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -153,47 +152,20 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 		src = node.License
 		dst = path.Join(c.Dir.Lab, "license.key")
 		if err = copyFile(src, dst); err != nil {
-			log.Errorf("CopyFile src %s -> dst %s failed %q\n", src, dst, err)
-			return err
+			return fmt.Errorf("CopyFile src %s -> dst %s failed %v", src, dst, err)
 		}
 		log.Debugf("CopyFile src %s -> dst %s succeeded", src, dst)
 
 		// create dut directory in lab
 		CreateDirectory(node.LabDir, 0777)
-
-		// copy topology to node specific directory in lab
-		src = node.Topology
-		dst = path.Join(node.LabDir, "topology.yml")
-		tpl, err := template.ParseFiles(src)
+		// generate SRL topology file
+		err = generateSRLTopologyFile(node.Topology, node.LabDir, node.Index)
 		if err != nil {
 			log.Fatalln(err)
 		}
-		type Mac struct {
-			MAC string
-		}
-		x := strconv.FormatInt(int64(node.Index), 16)
-		d2 := fmt.Sprintf("%02s", x)
-		m := "00:01:" + strings.ToUpper(d2) + ":00:00:00"
-		mac := Mac{
-			MAC: m,
-		}
-		log.Debug(mac, dst)
-		f, err := os.Create(dst)
-		if err != nil {
-			log.Error("create file: ", err)
-			return err
-		}
-		defer f.Close()
 
-		if err = tpl.Execute(f, mac); err != nil {
-			panic(err)
-		}
-		log.Debug(fmt.Sprintf("CopyFile GoTemplate src %s -> dat %s succeeded\n", src, dst))
-
-		// copy config file to node specific directory in lab
-
-		CreateDirectory(node.LabDir+"/"+"config", 0777)
-
+		// generate a config file if the destination does not exist
+		CreateDirectory(path.Join(node.LabDir, "config"), 0777)
 		dst = path.Join(node.LabDir, "config", "config.json")
 		if !fileExists(dst) {
 			err = node.generateConfig(dst)
@@ -206,15 +178,13 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 		node.Config = dst
 
 		// copy env config to node specific directory in lab
-
 		src = "/etc/containerlab/templates/srl/srl_env.conf"
 		dst = node.LabDir + "/" + "srlinux.conf"
 		err = copyFile(src, dst)
 		if err != nil {
-			log.Error(fmt.Sprintf("CopyFile src %s -> dat %s failed %q\n", src, dst, err))
-			return err
+			return fmt.Errorf("CopyFile src %s -> dst %s failed %v", src, dst, err)
 		}
-		log.Debug(fmt.Sprintf("CopyFile src %s -> dat %s succeeded\n", src, dst))
+		log.Debug(fmt.Sprintf("CopyFile src %s -> dst %s succeeded\n", src, dst))
 		node.EnvConf = dst
 
 	case "alpine":
@@ -256,7 +226,7 @@ func (node *Node) generateConfig(dst string) error {
 	if err != nil {
 		return err
 	}
-	log.Debugf("config:\n%s", dstBytes.String())
+	log.Debugf("node '%s' generated config: %s", node.ShortName, dstBytes.String())
 	f, err := os.Create(dst)
 	if err != nil {
 		return err

--- a/clab/srl.go
+++ b/clab/srl.go
@@ -1,0 +1,43 @@
+package clab
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"text/template"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type mac struct {
+	MAC string
+}
+
+func generateSRLTopologyFile(src, labDir string, index int) error {
+	dst := path.Join(labDir, "topology.yml")
+	tpl, err := template.ParseFiles(src)
+	if err != nil {
+		return err
+	}
+
+	x := strconv.FormatInt(int64(index), 16)
+	d2 := fmt.Sprintf("%02s", x)
+	m := "00:01:" + strings.ToUpper(d2) + ":00:00:00"
+	mac := mac{
+		MAC: m,
+	}
+	log.Debug(mac, dst)
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err = tpl.Execute(f, mac); err != nil {
+		panic(err)
+	}
+	log.Debugf("CopyFile GoTemplate src %s -> dat %s succeeded\n", src, dst)
+	return nil
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -102,7 +102,7 @@ var deployCmd = &cobra.Command{
 				log.Error(err)
 			}
 
-			if err = c.CreateContainer(ctx, shortDutName, node); err != nil {
+			if err = c.CreateContainer(ctx, node); err != nil {
 				log.Error(err)
 			}
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -98,6 +98,9 @@ var deployCmd = &cobra.Command{
 				log.Debugf("%s Cert: %s", shortDutName, string(nodeCerts.Cert))
 				log.Debugf("%s Key: %s", shortDutName, string(nodeCerts.Key))
 			}
+			
+			node.TLSCert = string(nodeCerts.Cert)
+			node.TLSKey = string(nodeCerts.Key)
 			if err = c.CreateNodeDirStructure(node, shortDutName); err != nil {
 				log.Error(err)
 			}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -60,10 +60,9 @@ var destroyCmd = &cobra.Command{
 
 		log.Info("Destroying container lab: ... ", topo)
 		// delete containers
-		for shortDutName, node := range c.Nodes {
-			if err = c.DeleteContainer(ctx, shortDutName, node); err != nil {
-				log.Error(err)
-			}
+		err = c.DeleteContainers(ctx, c.Conf.Prefix)
+		if err != nil {
+			log.Errorf("failed to delete containers: %v", err)
 		}
 		// delete container management bridge
 		log.Info("Deleting docker bridge ...")


### PR DESCRIPTION
Added concurrency for certificates generation and link wiring.
Container creating is still pretty much sequential, controlled via a RWmutex.
Deploy time for a 6 nodes / 10 links topology went down from ~11s to ~5s