### PR TITLE
fixed path to the dir in the log msg

### DIFF
--- a/clab/file.go
+++ b/clab/file.go
@@ -134,7 +134,8 @@ func createFile(file, content string) {
 	}
 }
 
-// CreateDirectory creates a directory
+// CreateDirectory creates a directory by a path with a mode/permission specified by perm.
+// If directory exists, the function does not do anything.
 func CreateDirectory(path string, perm os.FileMode) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		os.Mkdir(path, perm)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -22,8 +22,8 @@ var ipv6Subnet net.IPNet
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
-	Use:   "deploy",
-	Short: "deploy a lab",
+	Use:     "deploy",
+	Short:   "deploy a lab",
 	Aliases: []string{"dep"},
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
@@ -46,7 +46,7 @@ var deployCmd = &cobra.Command{
 		defer cancel()
 
 		// create lab directory
-		log.Info("Creating container lab directory: ", topo)
+		log.Info("Creating lab directory: ", c.Dir.Lab)
 		clab.CreateDirectory(c.Dir.Lab, 0755)
 
 		// create root CA


### PR DESCRIPTION
the log message that says by which path a directory is about to be created used the topo path, not the lab path.

```bash
# before
INFO[0000] Creating container lab directory: /etc/containerlab/lab-examples/wan-topo.yml

# after
INFO[0000] Creating container lab directory: /root/container-lab/containerlab-wan
```