### PR TITLE
Use netlink and netns package for interfaces/netns deletion

### DIFF
--- a/clab/netlink.go
+++ b/clab/netlink.go
@@ -3,6 +3,7 @@ package clab
 import (
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
 )
 
 func (c *cLab) InitVirtualWiring() {
@@ -153,28 +155,16 @@ func (c *cLab) createvethToBridge(l *Link) error {
 	return nil
 }
 
-// DeleteVirtualWiring deletes the virtual wiring
+// DeleteVirtualWiring deletes the virtual wiring by deleting network namespaces
 func (c *cLab) DeleteVirtualWiring(id int, link *Link) (err error) {
-	log.Info("Delete virtual wire :", link.A.Node.ShortName, link.B.Node.ShortName, link.A.EndpointName, link.B.EndpointName)
-
-	var cmd *exec.Cmd
+	log.Infof("Deleting virtual wire %s:%s<-->%s:%s", link.A.Node.ShortName, link.A.EndpointName, link.B.Node.ShortName, link.B.EndpointName)
 
 	if link.A.Node.Kind != "bridge" {
-		log.Debug("Delete netns: ", link.A.Node.LongName)
-		cmd = exec.Command("sudo", "ip", "netns", "del", link.A.Node.LongName)
-		err = runCmd(cmd)
-		if err != nil {
-			log.Debugf("%s failed with: %v", cmd.String(), err)
-		}
+		deleteNamedNetns(link.A.Node.LongName)
 	}
 
 	if link.B.Node.Kind != "bridge" {
-		log.Debug("Delete netns: ", link.B.Node.LongName)
-		cmd = exec.Command("sudo", "ip", "netns", "del", link.B.Node.LongName)
-		err = runCmd(cmd)
-		if err != nil {
-			log.Debugf("%s failed with: %v", cmd.String(), err)
-		}
+		deleteNamedNetns(link.B.Node.LongName)
 	}
 
 	return nil
@@ -194,4 +184,21 @@ func runCmd(cmd *exec.Cmd) error {
 func genIfName() string {
 	s, _ := uuid.New().MarshalText() // .MarshalText() always return a nil error
 	return string(s[:8])
+}
+
+// deleteNamedNetns deletes a network namespace and removes the symlink created by linkContainerNS func
+func deleteNamedNetns(n string) error {
+	log.Debug("Deleting netns: ", n)
+	err := netns.DeleteNamed(n)
+	if err != nil {
+		log.Debugf("Failed to delete namespace %s: %v", n, err)
+	}
+	// remove symlink created by linkContainerNS
+	log.Debug("Deleting netns symlink: ", n)
+	sl := fmt.Sprintf("/run/netns/%s", n)
+	err = os.Remove(sl)
+	if err != nil {
+		log.Debug("Failed to delete netns symlink by path:", sl)
+	}
+	return nil
 }

--- a/clab/netlink.go
+++ b/clab/netlink.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
 )
 
 func (c *cLab) InitVirtualWiring() {
-	var cmd *exec.Cmd
-	// list intefaces
+	// list interfaces
 	log.Debug("listing system interfaces...")
 	interfaces, err := net.Interfaces()
 	if err != nil {
@@ -24,10 +24,13 @@ func (c *cLab) InitVirtualWiring() {
 	for i := range interfaces {
 		if strings.HasPrefix(interfaces[i].Name, "clab-") {
 			log.Debugf("deleting interface %s", interfaces[i].Name)
-			cmd = exec.Command("sudo", "ip", "link", "del", interfaces[i].Name)
-			err = runCmd(cmd)
+			l, err := netlink.LinkByName(interfaces[i].Name)
 			if err != nil {
-				log.Debugf("%s failed with: %v", cmd.String(), err)
+				log.Debugf("failed to find interface for deletion by name: %v", interfaces[i].Name)
+			}
+			err = netlink.LinkDel(l)
+			if err != nil {
+				log.Debugf("failed to delete interface %s: %v", interfaces[i].Name, err)
 			}
 		}
 	}

--- a/clab/netlink.go
+++ b/clab/netlink.go
@@ -75,6 +75,7 @@ func (c *cLab) createAToBveth(l *Link) error {
 	wg.Wait()
 	return nil
 }
+
 func (c *cLab) configVeth(dummyInterface, endpointName, ns string) error {
 	var cmd *exec.Cmd
 	var err error
@@ -104,6 +105,7 @@ func (c *cLab) configVeth(dummyInterface, endpointName, ns string) error {
 	}
 	return nil
 }
+
 func (c *cLab) createvethToBridge(l *Link) error {
 	var cmd *exec.Cmd
 	var err error
@@ -156,7 +158,7 @@ func (c *cLab) createvethToBridge(l *Link) error {
 }
 
 // DeleteVirtualWiring deletes the virtual wiring by deleting network namespaces
-func (c *cLab) DeleteVirtualWiring(id int, link *Link) (err error) {
+func (c *cLab) DeleteVirtualWiring(link *Link) (err error) {
 	log.Infof("Deleting virtual wire %s:%s<-->%s:%s", link.A.Node.ShortName, link.A.EndpointName, link.B.Node.ShortName, link.B.EndpointName)
 
 	if link.A.Node.Kind != "bridge" {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -13,8 +13,8 @@ import (
 
 // destroyCmd represents the destroy command
 var destroyCmd = &cobra.Command{
-	Use:   "destroy",
-	Short: "destroy a lab",
+	Use:     "destroy",
+	Short:   "destroy a lab",
 	Aliases: []string{"des"},
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
@@ -70,8 +70,8 @@ var destroyCmd = &cobra.Command{
 			log.Error(err)
 		}
 		// delete virtual wiring
-		for n, link := range c.Links {
-			if err = c.DeleteVirtualWiring(n, link); err != nil {
+		for _, link := range c.Links {
+			if err = c.DeleteVirtualWiring(link); err != nil {
 				log.Error(err)
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vishvananda/netlink v1.1.0
+	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,10 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
@@ -202,6 +206,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJ
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/weppos/publicsuffix-go v0.4.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
 github.com/weppos/publicsuffix-go v0.5.0 h1:rutRtjBJViU/YjcI5d80t4JAVvDltS6bciJg2K1HrLU=
 github.com/weppos/publicsuffix-go v0.5.0/go.mod h1:z3LCPQ38eedDQSwmsSRW4Y7t2L8Ln16JPQ02lHAdn5k=
@@ -207,6 +209,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This PR removes some dependancies on iproute2 util in favor of netns and netlink packages that are used by container engines.

