### PR TITLE
removed prefixing slash from containers name returned by "inspect" cmd

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
@@ -33,7 +34,7 @@ var inspectCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		if prefix == "" && topo == "" {
-			fmt.Println("provide either lab prefix (--prefix) or topology file path (--topo)")
+			fmt.Println("provide either a lab prefix (--prefix) or a topology file path (--topo)")
 			return
 		}
 		c := clab.NewContainerLab(debug)
@@ -73,7 +74,8 @@ var inspectCmd = &cobra.Command{
 				State: cont.State,
 			}
 			if len(cont.Names) > 0 {
-				cdet.Name = cont.Names[0]
+				// we remove a "/" prefix from the container name returned by docker inspect cmd
+				cdet.Name = strings.TrimLeft(cont.Names[0], "/")
 			}
 			if kind, ok := cont.Labels["kind"]; ok {
 				cdet.Kind = kind

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,8 +40,8 @@ func Execute() {
 func init() {
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "enable debug mode")
-	rootCmd.PersistentFlags().StringVarP(&topo, "topo", "t", "/etc/containerlab/lab-examples/wan-topo.yml", "path to the file with topology information")
+	rootCmd.PersistentFlags().StringVarP(&topo, "topo", "t", "", "path to the file with topology information")
 	rootCmd.PersistentFlags().StringVarP(&prefix, "prefix", "p", "", "lab name prefix")
-	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "", 30 *time.Second, "timeout for docker requests, e.g: 30s, 1m, 2m30s")
+	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "", 30*time.Second, "timeout for docker requests, e.g: 30s, 1m, 2m30s")
 
 }


### PR DESCRIPTION
Docker inspect cmd uses FQDN for container names which start with "/"
unfortunately, this is inconsistent with the rest of the CLI commands, which take a non-slashed names as their arguments.

In this PR I removed the "/" from the container name for the `containerlab inspect` command:
```
❯ ../container-lab/container-lab inspect -t 1_srl.yml                                                                                                                                                                                                                      ─╯
INFO[0000] Getting topology information ...             
+------------------------+--------------------+------+-------+---------+----------------+----------------------+
|          Name          |       Image        | Kind | Group |  State  |  IPv4 Address  |     IPv6 Address     |
+------------------------+--------------------+------+-------+---------+----------------+----------------------+
| containerlab-1srl-srl1 | srlinux:20.6.1-286 | srl  |       | running | 172.19.20.2/24 | 2001:172:19:20::2/80 |
+------------------------+--------------------+------+-------+---------+----------------+----------------------+
```

Additionally, I removed the default topo file, which I think is a bit misleading