### PR TITLE
decouple container creation and container details retrieval

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -50,9 +50,9 @@ func (c *cLab) Init(timeout time.Duration) (err error) {
 
 func (c *cLab) CreateNode(ctx context.Context, node *Node, certs *certificates) error {
 	c.m.Lock()
-	defer c.m.Unlock()
 	node.TLSCert = string(certs.Cert)
 	node.TLSKey = string(certs.Key)
+	c.m.Unlock()
 	err := c.CreateNodeDirStructure(node)
 	if err != nil {
 		return err

--- a/clab/config.go
+++ b/clab/config.go
@@ -87,11 +87,6 @@ type Node struct {
 	Mounts    map[string]volume
 	Volumes   map[string]struct{}
 	Binds     []string
-	Pid       int
-	Cid       string
-	MgmtIPv4  string
-	MgmtIPv6  string
-	MgmtMac   string
 
 	TLSCert   string
 	TLSKey    string

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -184,7 +184,10 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	if err != nil {
 		return err
 	}
-	return linkContainerNS(cJson.State.Pid, node.LongName)
+	if len(c.Links) >= 0 {
+		return linkContainerNS(cJson.State.Pid, node.LongName)
+	}
+	return nil
 }
 
 func (c *cLab) PullImageIfRequired(ctx context.Context, node *Node) (err error) {

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -184,10 +184,7 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	if err != nil {
 		return err
 	}
-	if len(c.Links) >= 0 {
-		return linkContainerNS(cJson.State.Pid, node.LongName)
-	}
-	return nil
+	return linkContainerNS(cJson.State.Pid, node.LongName)
 }
 
 func (c *cLab) PullImageIfRequired(ctx context.Context, node *Node) (err error) {

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -271,6 +271,8 @@ func (c *cLab) InspectContainer(ctx context.Context, node *Node) error {
 
 // ListContainers lists all containers with labels []string
 func (c *cLab) ListContainers(ctx context.Context, labels []string) ([]types.Container, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
 	filter := filters.NewArgs()
 	for _, l := range labels {
 		filter.Add("label", l)

--- a/clab/file.go
+++ b/clab/file.go
@@ -198,7 +198,7 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 	return nil
 }
 
-func (c *cLab) CreateLabOutput() (err error) {
+func (c *cLab) CreateHostsFile() {
 	var v4Hosts []string
 	var v6Hosts []string
 	for dutName, node := range c.Nodes {
@@ -207,13 +207,11 @@ func (c *cLab) CreateLabOutput() (err error) {
 			v4Hosts = append(v4Hosts, fmt.Sprintf("%s \t\t\t %s\n", node.MgmtIPv4, node.LongName))
 			v6Hosts = append(v6Hosts, fmt.Sprintf("%s \t\t %s\n", node.MgmtIPv6, node.LongName))
 		}
-
 	}
 
 	hosts := append(v4Hosts, v6Hosts...)
 	createFile(path.Join(c.Dir.Lab, "hosts"), strings.Join(hosts, ""))
 	log.Infof("Generated hosts filename: %s", path.Join(c.Dir.Lab, "hosts"))
-	return nil
 }
 
 // GenerateConfig generates configuration for the duts

--- a/clab/file.go
+++ b/clab/file.go
@@ -198,21 +198,6 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 	return nil
 }
 
-func (c *cLab) CreateHostsFile() {
-	var v4Hosts []string
-	var v6Hosts []string
-	for dutName, node := range c.Nodes {
-		if node.Kind != "bridge" {
-			log.Infof("Mgmt IP addresses of container: %s, ContainerName: %s, IPv4: %s, IPv6: %s, MAC: %s", dutName, node.LongName, node.MgmtIPv4, node.MgmtIPv6, node.MgmtMac)
-			v4Hosts = append(v4Hosts, fmt.Sprintf("%s \t\t\t %s\n", node.MgmtIPv4, node.LongName))
-			v6Hosts = append(v6Hosts, fmt.Sprintf("%s \t\t %s\n", node.MgmtIPv6, node.LongName))
-		}
-	}
-
-	hosts := append(v4Hosts, v6Hosts...)
-	createFile(path.Join(c.Dir.Lab, "hosts"), strings.Join(hosts, ""))
-	log.Infof("Generated hosts filename: %s", path.Join(c.Dir.Lab, "hosts"))
-}
 
 // GenerateConfig generates configuration for the duts
 func (node *Node) generateConfig(dst string) error {

--- a/clab/file.go
+++ b/clab/file.go
@@ -144,6 +144,8 @@ func CreateDirectory(path string, perm os.FileMode) {
 
 // CreateNodeDirStructure create the directory structure and files for the clab
 func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
 	switch node.Kind {
 	case "srl":
 		log.Infof("Create directory structure for SRL container: %s", node.ShortName)
@@ -162,7 +164,7 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 		// generate SRL topology file
 		err = generateSRLTopologyFile(node.Topology, node.LabDir, node.Index)
 		if err != nil {
-			log.Fatalln(err)
+			return err
 		}
 
 		// generate a config file if the destination does not exist
@@ -176,7 +178,6 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 		} else {
 			log.Debugf("Config File Exists for node %s", node.ShortName)
 		}
-		node.Config = dst
 
 		// copy env config to node specific directory in lab
 		src = "/etc/containerlab/templates/srl/srl_env.conf"
@@ -185,8 +186,7 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 		if err != nil {
 			return fmt.Errorf("CopyFile src %s -> dst %s failed %v", src, dst, err)
 		}
-		log.Debug(fmt.Sprintf("CopyFile src %s -> dst %s succeeded\n", src, dst))
-		node.EnvConf = dst
+		log.Debugf("CopyFile src %s -> dst %s succeeded\n", src, dst)
 
 	case "alpine":
 	case "linux":

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -126,9 +126,7 @@ var deployCmd = &cobra.Command{
 		}
 
 		// show topology output
-		if err = c.CreateLabOutput(); err != nil {
-			log.Error(err)
-		}
+		c.CreateHostsFile()
 		return nil
 	},
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -60,11 +60,10 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to generate rootCa: %v", err)
 		}
-		if debug {
-			log.Debugf("root CSR: %s", string(rootCerts.Csr))
-			log.Debugf("root Cert: %s", string(rootCerts.Cert))
-			log.Debugf("root Key: %s", string(rootCerts.Key))
-		}
+
+		log.Debugf("root CSR: %s", string(rootCerts.Csr))
+		log.Debugf("root Cert: %s", string(rootCerts.Cert))
+		log.Debugf("root Key: %s", string(rootCerts.Key))
 
 		// create bridge
 		if err = c.CreateBridge(ctx); err != nil {
@@ -104,10 +103,6 @@ var deployCmd = &cobra.Command{
 			}(node)
 		}
 		wg.Wait()
-		err = c.SetNodesDetails(ctx)
-		if err != nil {
-			return err
-		}
 		// cleanup hanging resources if a deployment failed before
 		c.InitVirtualWiring()
 		wg = new(sync.WaitGroup)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -104,6 +104,10 @@ var deployCmd = &cobra.Command{
 			}(node)
 		}
 		wg.Wait()
+		err = c.SetNodesDetails(ctx)
+		if err != nil {
+			return err
+		}
 		// cleanup hanging resources if a deployment failed before
 		c.InitVirtualWiring()
 		wg = new(sync.WaitGroup)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -131,6 +131,17 @@ var deployCmd = &cobra.Command{
 
 		// show topology output
 		c.CreateHostsFile()
+
+		// print table summary
+		labels = append(labels, "containerlab=lab-"+c.Conf.Prefix)
+		containers, err := c.ListContainers(ctx, labels)
+		if err != nil {
+			return fmt.Errorf("could not list containers: %v", err)
+		}
+		if len(containers) == 0 {
+			return fmt.Errorf("no containers found")
+		}
+		printContainerInspect(containers, c.Conf.DockerInfo.Bridge, format)
 		return nil
 	},
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/olekukonko/tablewriter"
@@ -94,7 +95,7 @@ func printContainerInspect(containers []types.Container, bridgeName string, form
 			State: cont.State,
 		}
 		if len(cont.Names) > 0 {
-			cdet.Name = cont.Names[0]
+			cdet.Name = strings.TrimLeft(cont.Names[0], "/")
 		}
 		if kind, ok := cont.Labels["kind"]; ok {
 			cdet.Kind = kind

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/docker/api/types"
 	"github.com/olekukonko/tablewriter"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -66,61 +67,7 @@ var inspectCmd = &cobra.Command{
 			fmt.Println(string(b))
 			return
 		}
-		contDetails := make([]containerDetails, 0, len(containers))
-		for _, cont := range containers {
-			cdet := containerDetails{
-				Image: cont.Image,
-				State: cont.State,
-			}
-			if len(cont.Names) > 0 {
-				cdet.Name = cont.Names[0]
-			}
-			if kind, ok := cont.Labels["kind"]; ok {
-				cdet.Kind = kind
-			}
-			if group, ok := cont.Labels["group"]; ok {
-				cdet.Group = group
-			}
-			if cont.NetworkSettings != nil {
-				if c.Conf.DockerInfo.Bridge != "" {
-					if br, ok := cont.NetworkSettings.Networks[c.Conf.DockerInfo.Bridge]; ok {
-						cdet.IPv4Address = fmt.Sprintf("%s/%d", br.IPAddress, br.IPPrefixLen)
-						cdet.IPv6Address = fmt.Sprintf("%s/%d", br.GlobalIPv6Address, br.GlobalIPv6PrefixLen)
-					}
-				}
-				if cdet.IPv4Address == "" && cdet.IPv6Address == "" {
-					for _, br := range cont.NetworkSettings.Networks {
-						cdet.IPv4Address = fmt.Sprintf("%s/%d", br.IPAddress, br.IPPrefixLen)
-						cdet.IPv6Address = fmt.Sprintf("%s/%d", br.GlobalIPv6Address, br.GlobalIPv6PrefixLen)
-						break
-					}
-				}
-			}
-			contDetails = append(contDetails, cdet)
-		}
-		if format == "json" {
-			b, err := json.MarshalIndent(contDetails, "", "  ")
-			if err != nil {
-				log.Fatalf("failed to marshal container details: %v", err)
-			}
-			fmt.Println(string(b))
-			return
-		}
-		tabData := toTableData(contDetails)
-		table := tablewriter.NewWriter(os.Stdout)
-		table.SetHeader([]string{
-			"Name",
-			"Image",
-			"Kind",
-			"Group",
-			"State",
-			"IPv4 Address",
-			"IPv6 Address",
-		})
-		table.SetAutoFormatHeaders(false)
-		table.SetAutoWrapText(false)
-		table.AppendBulk(tabData)
-		table.Render()
+		printContainerInspect(containers, c.Conf.DockerInfo.Bridge, format)
 	},
 }
 
@@ -137,4 +84,62 @@ func toTableData(det []containerDetails) [][]string {
 		tabData = append(tabData, []string{d.Name, d.Image, d.Kind, d.Group, d.State, d.IPv4Address, d.IPv6Address})
 	}
 	return tabData
+}
+
+func printContainerInspect(containers []types.Container, bridgeName string, format string) {
+	contDetails := make([]containerDetails, 0, len(containers))
+	for _, cont := range containers {
+		cdet := containerDetails{
+			Image: cont.Image,
+			State: cont.State,
+		}
+		if len(cont.Names) > 0 {
+			cdet.Name = cont.Names[0]
+		}
+		if kind, ok := cont.Labels["kind"]; ok {
+			cdet.Kind = kind
+		}
+		if group, ok := cont.Labels["group"]; ok {
+			cdet.Group = group
+		}
+		if cont.NetworkSettings != nil {
+			if bridgeName != "" {
+				if br, ok := cont.NetworkSettings.Networks[bridgeName]; ok {
+					cdet.IPv4Address = fmt.Sprintf("%s/%d", br.IPAddress, br.IPPrefixLen)
+					cdet.IPv6Address = fmt.Sprintf("%s/%d", br.GlobalIPv6Address, br.GlobalIPv6PrefixLen)
+				}
+			}
+			if cdet.IPv4Address == "" && cdet.IPv6Address == "" {
+				for _, br := range cont.NetworkSettings.Networks {
+					cdet.IPv4Address = fmt.Sprintf("%s/%d", br.IPAddress, br.IPPrefixLen)
+					cdet.IPv6Address = fmt.Sprintf("%s/%d", br.GlobalIPv6Address, br.GlobalIPv6PrefixLen)
+					break
+				}
+			}
+		}
+		contDetails = append(contDetails, cdet)
+	}
+	if format == "json" {
+		b, err := json.MarshalIndent(contDetails, "", "  ")
+		if err != nil {
+			log.Fatalf("failed to marshal container details: %v", err)
+		}
+		fmt.Println(string(b))
+		return
+	}
+	tabData := toTableData(contDetails)
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"Name",
+		"Image",
+		"Kind",
+		"Group",
+		"State",
+		"IPv4 Address",
+		"IPv6 Address",
+	})
+	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
+	table.AppendBulk(tabData)
+	table.Render()
 }


### PR DESCRIPTION
This PR decouples containers creation/starting and container inspect to get the IPs and PID.
This allows to run the creation and starting functions concurrently.

This PR also rewrites the hosts file generation function, as well as moving the inspect cmd table output to a separate function to allow its reuse in deploy command.

Got rid of a few log.Fatal as well, replaced by returning an error on the cobra command level