### PR TITLE
refactored netns symlinks removal

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -69,12 +69,8 @@ var destroyCmd = &cobra.Command{
 		if err = c.DeleteBridge(ctx); err != nil {
 			log.Error(err)
 		}
-		// delete virtual wiring
-		for _, link := range c.Links {
-			if err = c.DeleteVirtualWiring(link); err != nil {
-				log.Error(err)
-			}
-		}
+		// delete container network namespaces symlinks
+		c.DeleteNetnsSymlinks()
 		c.InitVirtualWiring()
 	},
 }


### PR DESCRIPTION
in this PR the explicit removal of the container network namespaces has been removed.
There is no need to remove the namespaces manually as this will be handled by the docker daemon upon container deletion.

Instead, the function has been renamed to reflect its only value - which is removal of symlinks we create for netns in `/run/netns` 