### PR TITLE
Use syscalls to disable TX csum offload

### DIFF
--- a/clab/docker.go
+++ b/clab/docker.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -105,13 +104,11 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 		return fmt.Errorf("failed to enable LLDP on docker bridge: %v", err)
 	}
 
-	log.Debug("Disable Checksum Offloading on the docker bridge")
-	var b []byte
-	b, err = exec.Command("sudo", "ethtool", "--offload", bridgeName, "rx", "off", "tx", "off").CombinedOutput()
+	log.Debugf("Disabling TX checksum offloading for the %s bridge interface...", bridgeName)
+	err = EthtoolTXOff(bridgeName)
 	if err != nil {
-		return fmt.Errorf("failed to disable Checksum Offloading on docker bridge: %v", err)
+		return fmt.Errorf("Failed to disable TX checksum offloading for the %s bridge interface: %v", bridgeName, err)
 	}
-	log.Debugf("%s", string(b))
 	return nil
 }
 

--- a/clab/ethtool.go
+++ b/clab/ethtool.go
@@ -1,0 +1,62 @@
+package clab
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	SIOCETHTOOL     = 0x8946     // linux/sockios.h
+	ETHTOOL_GTXCSUM = 0x00000016 // linux/ethtool.h
+	ETHTOOL_STXCSUM = 0x00000017 // linux/ethtool.h
+	IFNAMSIZ        = 16         // linux/if.h
+)
+
+// linux/if.h 'struct ifreq'
+type IFReqData struct {
+	Name [IFNAMSIZ]byte
+	Data uintptr
+}
+
+// linux/ethtool.h 'struct ethtool_value'
+type EthtoolValue struct {
+	Cmd  uint32
+	Data uint32
+}
+
+func ioctlEthtool(fd int, argp uintptr) error {
+	_, _, errno := syscall.RawSyscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(SIOCETHTOOL), argp)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// EthtoolTXOff disables TX checksum offload on specified interface
+func EthtoolTXOff(name string) error {
+	if len(name)+1 > IFNAMSIZ {
+		return fmt.Errorf("name too long")
+	}
+
+	socket, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.Close(socket)
+
+	// Request current value
+	value := EthtoolValue{Cmd: ETHTOOL_GTXCSUM}
+	request := IFReqData{Data: uintptr(unsafe.Pointer(&value))}
+	copy(request.Name[:], name)
+
+	if err := ioctlEthtool(socket, uintptr(unsafe.Pointer(&request))); err != nil {
+		return err
+	}
+	if value.Data == 0 { // if already off, don't try to change
+		return nil
+	}
+
+	value = EthtoolValue{ETHTOOL_STXCSUM, 0}
+	return ioctlEthtool(socket, uintptr(unsafe.Pointer(&request)))
+}


### PR DESCRIPTION
Instead of using the `ethtool` the code now uses native linux syscalls to disalbe TX checksum offload.
