### PR TITLE
exit if not running as root 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,12 @@ func Execute() {
 }
 
 func init() {
+	id := os.Geteuid()
+	if id != 0 {
+		fmt.Println("containerlab requires sudo privileges to run!")
+		os.Exit(1)
+	}
+
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "enable debug mode")
 	rootCmd.PersistentFlags().StringVarP(&topo, "topo", "t", "", "path to the file with topology information")


### PR DESCRIPTION
```bash
# first run without sudo as a regular user
[test@srl-centos7 ~]$ /tmp/container-lab
containerlab requires sudo privileges to run!

# now with sudo
[test@srl-centos7 ~]$ sudo /tmp/container-lab

We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

[sudo] password for test:
deploy container based lab environments with a user-defined interconnections

Usage:
  containerlab [command]

Available Commands:
  config      generate and apply configuration to the lab
```

also ensured that deploy/destroy cmds work

close #105 