### PR TITLE
implement short clab prefix instead of a longer `containerlab` one

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -10,11 +10,6 @@ import (
 
 // var debug bool
 
-const (
-	prefix    string = "clab"
-	dockerNet string = "clab"
-)
-
 type cLab struct {
 	Conf         *Conf
 	FileInfo     *File

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -10,6 +10,11 @@ import (
 
 // var debug bool
 
+const (
+	prefix    string = "clab"
+	dockerNet string = "clab"
+)
+
 type cLab struct {
 	Conf         *Conf
 	FileInfo     *File

--- a/clab/config.go
+++ b/clab/config.go
@@ -11,11 +11,13 @@ import (
 )
 
 const (
-	baseConfigDir  = "/etc/containerlab/templates/srl/"
-	prefix         = "clab"
-	dockerNetName  = "clab"
-	dockerIPv4Addr = "172.20.20.0/24"
-	dockerIPv6Addr = "2001:172:20:20::/80"
+	baseConfigDir = "/etc/containerlab/templates/srl/"
+	// prefix is used to distinct containerlab created files/dirs/containers
+	prefix = "clab"
+	// a name of a docker network that nodes management interfaces connect to
+	dockerNetName     = "clab"
+	dockerNetIPv4Addr = "172.20.20.0/24"
+	dockerNetIPv6Addr = "2001:172:20:20::/80"
 )
 
 var srlTypes = map[string]string{
@@ -120,10 +122,10 @@ func (c *cLab) parseIPInfo() error {
 		c.Conf.DockerInfo.Bridge = dockerNetName
 	}
 	if c.Conf.DockerInfo.Ipv4Subnet == "" {
-		c.Conf.DockerInfo.Ipv4Subnet = dockerIPv4Addr
+		c.Conf.DockerInfo.Ipv4Subnet = dockerNetIPv4Addr
 	}
 	if c.Conf.DockerInfo.Ipv6Subnet == "" {
-		c.Conf.DockerInfo.Ipv6Subnet = dockerIPv6Addr
+		c.Conf.DockerInfo.Ipv6Subnet = dockerNetIPv6Addr
 	}
 
 	_, ipv4Net, err := net.ParseCIDR(c.Conf.DockerInfo.Ipv4Subnet)

--- a/clab/config.go
+++ b/clab/config.go
@@ -10,7 +10,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const baseConfigDir = "/etc/containerlab/templates/srl/"
+const (
+	baseConfigDir  = "/etc/containerlab/templates/srl/"
+	prefix         = "clab"
+	dockerNetName  = "clab"
+	dockerIPv4Addr = "172.20.20.0/24"
+	dockerIPv6Addr = "2001:172:20:20::/80"
+)
 
 var srlTypes = map[string]string{
 	"ixr6":  "topology-7250IXR6.yml",
@@ -100,7 +106,7 @@ type Link struct {
 	Labels map[string]string
 }
 
-// Endpoint is a sttruct that contains information of a link endpoint
+// Endpoint is a struct that contains information of a link endpoint
 type Endpoint struct {
 	Node *Node
 	// e1-x, eth, etc
@@ -111,13 +117,13 @@ type Endpoint struct {
 func (c *cLab) parseIPInfo() error {
 	// DockerInfo = t.DockerInfo
 	if c.Conf.DockerInfo.Bridge == "" {
-		c.Conf.DockerInfo.Bridge = dockerNet
+		c.Conf.DockerInfo.Bridge = dockerNetName
 	}
 	if c.Conf.DockerInfo.Ipv4Subnet == "" {
-		c.Conf.DockerInfo.Ipv4Subnet = "172.20.20.0/24"
+		c.Conf.DockerInfo.Ipv4Subnet = dockerIPv4Addr
 	}
 	if c.Conf.DockerInfo.Ipv6Subnet == "" {
-		c.Conf.DockerInfo.Ipv6Subnet = "2001:172:20:20::/80"
+		c.Conf.DockerInfo.Ipv6Subnet = dockerIPv6Addr
 	}
 
 	_, ipv4Net, err := net.ParseCIDR(c.Conf.DockerInfo.Ipv4Subnet)
@@ -171,7 +177,7 @@ func (c *cLab) ParseTopology() error {
 		idx++
 	}
 	for i, l := range c.Conf.Links {
-		// i represnts the endpoint integer and l provide the link struct
+		// i represents the endpoint integer and l provide the link struct
 		c.Links[i] = c.NewLink(l)
 	}
 	return nil

--- a/clab/config.go
+++ b/clab/config.go
@@ -111,13 +111,13 @@ type Endpoint struct {
 func (c *cLab) parseIPInfo() error {
 	// DockerInfo = t.DockerInfo
 	if c.Conf.DockerInfo.Bridge == "" {
-		c.Conf.DockerInfo.Bridge = "srlinux_bridge"
+		c.Conf.DockerInfo.Bridge = dockerNet
 	}
 	if c.Conf.DockerInfo.Ipv4Subnet == "" {
-		c.Conf.DockerInfo.Bridge = "172.19.19.0/24"
+		c.Conf.DockerInfo.Ipv4Subnet = "172.20.20.0/24"
 	}
 	if c.Conf.DockerInfo.Ipv6Subnet == "" {
-		c.Conf.DockerInfo.Bridge = "2001:172:19:19::/80"
+		c.Conf.DockerInfo.Ipv6Subnet = "2001:172:20:20::/80"
 	}
 
 	_, ipv4Net, err := net.ParseCIDR(c.Conf.DockerInfo.Ipv4Subnet)
@@ -155,7 +155,7 @@ func (c *cLab) ParseTopology() error {
 	}
 
 	c.Dir = new(cLabDirectory)
-	c.Dir.Lab = c.Conf.ConfigPath + "/" + "containerlab" + "-" + c.Conf.Prefix
+	c.Dir.Lab = c.Conf.ConfigPath + "/" + prefix + "-" + c.Conf.Prefix
 	c.Dir.LabCA = c.Dir.Lab + "/" + "ca"
 	c.Dir.LabCARoot = c.Dir.LabCA + "/" + "root"
 	c.Dir.LabGraph = c.Dir.Lab + "/" + "graph"
@@ -245,7 +245,7 @@ func (c *cLab) NewNode(dutName string, dut dutInfo, idx int) {
 	// initialize a new node
 	node := new(Node)
 	node.ShortName = dutName
-	node.LongName = "containerlab" + "-" + c.Conf.Prefix + "-" + dutName
+	node.LongName = prefix + "-" + c.Conf.Prefix + "-" + dutName
 	node.Fqdn = dutName + "." + c.Conf.Prefix + ".io"
 	node.LabDir = c.Dir.Lab + "/" + dutName
 	// node.CertDir = c.Dir.LabCA + "/" + dutName


### PR DESCRIPTION
close #104, #75 
