### PR TITLE
Topology definition rework

### DIFF
--- a/clab/cert.go
+++ b/clab/cert.go
@@ -79,7 +79,7 @@ func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Templa
 		Name:     node.ShortName,
 		LongName: node.LongName,
 		Fqdn:     node.Fqdn,
-		Prefix:   c.Conf.Prefix,
+		Prefix:   c.Conf.Name,
 	}
 	CreateDirectory(path.Join(c.Dir.LabCA, input.Name), 0755)
 	var err error

--- a/clab/cert.go
+++ b/clab/cert.go
@@ -79,7 +79,7 @@ func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Templa
 		Name:     node.ShortName,
 		LongName: node.LongName,
 		Fqdn:     node.Fqdn,
-		Prefix:   c.Conf.Name,
+		Prefix:   c.Config.Name,
 	}
 	CreateDirectory(path.Join(c.Dir.LabCA, input.Name), 0755)
 	var err error

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -11,7 +11,7 @@ import (
 // var debug bool
 
 type cLab struct {
-	Conf         *Conf
+	Config       *Config
 	TopoFile     *TopoFile
 	m            *sync.RWMutex
 	Nodes        map[string]*Node
@@ -33,7 +33,7 @@ type cLabDirectory struct {
 // NewContainerLab function defines a new container lab
 func NewContainerLab(d bool) *cLab {
 	return &cLab{
-		Conf:     new(Conf),
+		Config:   new(Config),
 		TopoFile: new(TopoFile),
 		m:        new(sync.RWMutex),
 		Nodes:    make(map[string]*Node),

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -42,6 +42,7 @@ func NewContainerLab(d bool) *cLab {
 	}
 }
 
+// Init creates a docker client and adds it to containerlab structure
 func (c *cLab) Init(timeout time.Duration) (err error) {
 	c.DockerClient, err = docker.NewEnvClient()
 	c.timeout = timeout

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -12,7 +12,7 @@ import (
 
 type cLab struct {
 	Conf         *Conf
-	FileInfo     *File
+	TopoFile     *TopoFile
 	m            *sync.RWMutex
 	Nodes        map[string]*Node
 	Links        map[int]*Link
@@ -34,7 +34,7 @@ type cLabDirectory struct {
 func NewContainerLab(d bool) *cLab {
 	return &cLab{
 		Conf:     new(Conf),
-		FileInfo: new(File),
+		TopoFile: new(TopoFile),
 		m:        new(sync.RWMutex),
 		Nodes:    make(map[string]*Node),
 		Links:    make(map[int]*Link),

--- a/clab/config.go
+++ b/clab/config.go
@@ -55,7 +55,7 @@ type Topology struct {
 }
 
 type link struct {
-	Endpoints []string          `yaml:"endpoints"`
+	Endpoints []string
 	Labels    map[string]string `yaml:"labels,omitempty"`
 }
 
@@ -64,7 +64,7 @@ type Config struct {
 	Name       string
 	Mgmt       mgmtNet
 	Topology   Topology
-	Links      []link `yaml:"Links"`
+	Links      []link
 	ConfigPath string `yaml:"config_path"`
 }
 

--- a/clab/config.go
+++ b/clab/config.go
@@ -53,10 +53,9 @@ type link struct {
 
 // Conf defines lab configuration as it is provided in the YAML file
 type Conf struct {
-	Name        string
-	Mgmt        mgmtNet
-	ClientImage string `yaml:"Client_image"`
-	Duts        struct {
+	Name string
+	Mgmt mgmtNet
+	Duts struct {
 		GlobalDefaults dutInfo            `yaml:"global_defaults"`
 		KindDefaults   map[string]dutInfo `yaml:"kind_defaults"`
 		DutSpecifics   map[string]dutInfo `yaml:"dut_specifics"`

--- a/clab/config.go
+++ b/clab/config.go
@@ -51,8 +51,8 @@ type link struct {
 	Labels    map[string]string `yaml:"labels,omitempty"`
 }
 
-// Conf defines lab configuration as it is provided in the YAML file
-type Conf struct {
+// Config defines lab configuration as it is provided in the YAML file
+type Config struct {
 	Name string
 	Mgmt mgmtNet
 	Duts struct {
@@ -116,14 +116,14 @@ type Endpoint struct {
 // ParseIPInfo parses IP information
 func (c *cLab) parseIPInfo() error {
 	// DockerInfo = t.DockerInfo
-	if c.Conf.Mgmt.Network == "" {
-		c.Conf.Mgmt.Network = dockerNetName
+	if c.Config.Mgmt.Network == "" {
+		c.Config.Mgmt.Network = dockerNetName
 	}
-	if c.Conf.Mgmt.Ipv4Subnet == "" {
-		c.Conf.Mgmt.Ipv4Subnet = dockerNetIPv4Addr
+	if c.Config.Mgmt.Ipv4Subnet == "" {
+		c.Config.Mgmt.Ipv4Subnet = dockerNetIPv4Addr
 	}
-	if c.Conf.Mgmt.Ipv6Subnet == "" {
-		c.Conf.Mgmt.Ipv6Subnet = dockerNetIPv6Addr
+	if c.Config.Mgmt.Ipv6Subnet == "" {
+		c.Config.Mgmt.Ipv6Subnet = dockerNetIPv6Addr
 	}
 	return nil
 }
@@ -131,20 +131,20 @@ func (c *cLab) parseIPInfo() error {
 // ParseTopology parses the lab topology
 func (c *cLab) ParseTopology() error {
 	log.Info("Parsing topology information ...")
-	log.Debugf("Prefix: %s", c.Conf.Name)
+	log.Debugf("Prefix: %s", c.Config.Name)
 	// initialize DockerInfo
 	err := c.parseIPInfo()
 	if err != nil {
 		return err
 	}
-	log.Debugf("DockerInfo: %v", c.Conf.Mgmt)
+	log.Debugf("DockerInfo: %v", c.Config.Mgmt)
 
-	if c.Conf.ConfigPath == "" {
-		c.Conf.ConfigPath, _ = filepath.Abs(os.Getenv("PWD"))
+	if c.Config.ConfigPath == "" {
+		c.Config.ConfigPath, _ = filepath.Abs(os.Getenv("PWD"))
 	}
 
 	c.Dir = new(cLabDirectory)
-	c.Dir.Lab = c.Conf.ConfigPath + "/" + prefix + "-" + c.Conf.Name
+	c.Dir.Lab = c.Config.ConfigPath + "/" + prefix + "-" + c.Config.Name
 	c.Dir.LabCA = c.Dir.Lab + "/" + "ca"
 	c.Dir.LabCARoot = c.Dir.LabCA + "/" + "root"
 	c.Dir.LabGraph = c.Dir.Lab + "/" + "graph"
@@ -155,11 +155,11 @@ func (c *cLab) ParseTopology() error {
 
 	// initialize the Node information from the topology map
 	idx := 0
-	for dut, data := range c.Conf.Duts.DutSpecifics {
+	for dut, data := range c.Config.Duts.DutSpecifics {
 		c.NewNode(dut, data, idx)
 		idx++
 	}
-	for i, l := range c.Conf.Links {
+	for i, l := range c.Config.Links {
 		// i represents the endpoint integer and l provide the link struct
 		c.Links[i] = c.NewLink(l)
 	}
@@ -170,52 +170,52 @@ func (c *cLab) kindInitialization(dut *dutInfo) string {
 	if dut.Kind != "" {
 		return dut.Kind
 	}
-	return c.Conf.Duts.GlobalDefaults.Kind
+	return c.Config.Duts.GlobalDefaults.Kind
 }
 
 func (c *cLab) groupInitialization(dut *dutInfo, kind string) string {
 	if dut.Group != "" {
 		return dut.Group
-	} else if c.Conf.Duts.KindDefaults[kind].Group != "" {
-		return c.Conf.Duts.KindDefaults[kind].Group
+	} else if c.Config.Duts.KindDefaults[kind].Group != "" {
+		return c.Config.Duts.KindDefaults[kind].Group
 	}
-	return c.Conf.Duts.GlobalDefaults.Group
+	return c.Config.Duts.GlobalDefaults.Group
 }
 
 func (c *cLab) typeInitialization(dut *dutInfo, kind string) string {
 	if dut.Type != "" {
 		return dut.Type
 	}
-	return c.Conf.Duts.KindDefaults[kind].Type
+	return c.Config.Duts.KindDefaults[kind].Type
 }
 
 func (c *cLab) configInitialization(dut *dutInfo, kind string) string {
 	if dut.Config != "" {
 		return dut.Config
 	}
-	return c.Conf.Duts.KindDefaults[kind].Config
+	return c.Config.Duts.KindDefaults[kind].Config
 }
 
 func (c *cLab) imageInitialization(dut *dutInfo, kind string) string {
 	if dut.Image != "" {
 		return dut.Image
 	}
-	return c.Conf.Duts.KindDefaults[kind].Image
+	return c.Config.Duts.KindDefaults[kind].Image
 }
 
 func (c *cLab) licenseInitialization(dut *dutInfo, kind string) string {
 	if dut.License != "" {
 		return dut.License
 	}
-	return c.Conf.Duts.KindDefaults[kind].License
+	return c.Config.Duts.KindDefaults[kind].License
 }
 
 func (c *cLab) cmdInitialization(dut *dutInfo, kind string, deflt string) string {
 	if dut.Cmd != "" {
 		return dut.Cmd
 	}
-	if c.Conf.Duts.KindDefaults[kind].Cmd != "" {
-		return c.Conf.Duts.KindDefaults[kind].Cmd
+	if c.Config.Duts.KindDefaults[kind].Cmd != "" {
+		return c.Config.Duts.KindDefaults[kind].Cmd
 	}
 	return deflt
 }
@@ -223,10 +223,10 @@ func (c *cLab) cmdInitialization(dut *dutInfo, kind string, deflt string) string
 func (c *cLab) positionInitialization(dut *dutInfo, kind string) string {
 	if dut.Position != "" {
 		return dut.Position
-	} else if c.Conf.Duts.KindDefaults[kind].Position != "" {
-		return c.Conf.Duts.KindDefaults[kind].Position
+	} else if c.Config.Duts.KindDefaults[kind].Position != "" {
+		return c.Config.Duts.KindDefaults[kind].Position
 	}
-	return c.Conf.Duts.GlobalDefaults.Position
+	return c.Config.Duts.GlobalDefaults.Position
 }
 
 // NewNode initializes a new node object
@@ -234,8 +234,8 @@ func (c *cLab) NewNode(dutName string, dut dutInfo, idx int) {
 	// initialize a new node
 	node := new(Node)
 	node.ShortName = dutName
-	node.LongName = prefix + "-" + c.Conf.Name + "-" + dutName
-	node.Fqdn = dutName + "." + c.Conf.Name + ".io"
+	node.LongName = prefix + "-" + c.Config.Name + "-" + dutName
+	node.Fqdn = dutName + "." + c.Config.Name + ".io"
 	node.LabDir = c.Dir.Lab + "/" + dutName
 	// node.CertDir = c.Dir.LabCA + "/" + dutName
 	node.Index = idx
@@ -420,7 +420,7 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 		if _, err := netlink.LinkByName(nName); err != nil {
 			log.Fatalf("Bridge %s is referenced in the endpoints section but was not found in the default network namespace", nName)
 		}
-		endpoint.EndpointName = c.Conf.Name + epName
+		endpoint.EndpointName = c.Config.Name + epName
 	} else {
 		endpoint.EndpointName = epName
 	}

--- a/clab/config.go
+++ b/clab/config.go
@@ -176,53 +176,53 @@ func (c *cLab) ParseTopology() error {
 	return nil
 }
 
-func (c *cLab) kindInitialization(dut *NodeConfig) string {
-	if dut.Kind != "" {
-		return dut.Kind
+func (c *cLab) kindInitialization(nodeCfg *NodeConfig) string {
+	if nodeCfg.Kind != "" {
+		return nodeCfg.Kind
 	}
 	return c.Config.Topology.Defaults.Kind
 }
 
-func (c *cLab) groupInitialization(dut *NodeConfig, kind string) string {
-	if dut.Group != "" {
-		return dut.Group
+func (c *cLab) groupInitialization(nodeCfg *NodeConfig, kind string) string {
+	if nodeCfg.Group != "" {
+		return nodeCfg.Group
 	} else if c.Config.Topology.Kinds[kind].Group != "" {
 		return c.Config.Topology.Kinds[kind].Group
 	}
 	return c.Config.Topology.Defaults.Group
 }
 
-func (c *cLab) typeInitialization(dut *NodeConfig, kind string) string {
-	if dut.Type != "" {
-		return dut.Type
+func (c *cLab) typeInitialization(nodeCfg *NodeConfig, kind string) string {
+	if nodeCfg.Type != "" {
+		return nodeCfg.Type
 	}
 	return c.Config.Topology.Kinds[kind].Type
 }
 
-func (c *cLab) configInitialization(dut *NodeConfig, kind string) string {
-	if dut.Config != "" {
-		return dut.Config
+func (c *cLab) configInitialization(nodeCfg *NodeConfig, kind string) string {
+	if nodeCfg.Config != "" {
+		return nodeCfg.Config
 	}
 	return c.Config.Topology.Kinds[kind].Config
 }
 
-func (c *cLab) imageInitialization(dut *NodeConfig, kind string) string {
-	if dut.Image != "" {
-		return dut.Image
+func (c *cLab) imageInitialization(nodeCfg *NodeConfig, kind string) string {
+	if nodeCfg.Image != "" {
+		return nodeCfg.Image
 	}
 	return c.Config.Topology.Kinds[kind].Image
 }
 
-func (c *cLab) licenseInitialization(dut *NodeConfig, kind string) string {
-	if dut.License != "" {
-		return dut.License
+func (c *cLab) licenseInitialization(nodeCfg *NodeConfig, kind string) string {
+	if nodeCfg.License != "" {
+		return nodeCfg.License
 	}
 	return c.Config.Topology.Kinds[kind].License
 }
 
-func (c *cLab) cmdInitialization(dut *NodeConfig, kind string, defCmd string) string {
-	if dut.Cmd != "" {
-		return dut.Cmd
+func (c *cLab) cmdInitialization(nodeCfg *NodeConfig, kind string, defCmd string) string {
+	if nodeCfg.Cmd != "" {
+		return nodeCfg.Cmd
 	}
 	if c.Config.Topology.Kinds[kind].Cmd != "" {
 		return c.Config.Topology.Kinds[kind].Cmd
@@ -230,9 +230,9 @@ func (c *cLab) cmdInitialization(dut *NodeConfig, kind string, defCmd string) st
 	return defCmd
 }
 
-func (c *cLab) positionInitialization(dut *NodeConfig, kind string) string {
-	if dut.Position != "" {
-		return dut.Position
+func (c *cLab) positionInitialization(nodeCfg *NodeConfig, kind string) string {
+	if nodeCfg.Position != "" {
+		return nodeCfg.Position
 	} else if c.Config.Topology.Kinds[kind].Position != "" {
 		return c.Config.Topology.Kinds[kind].Position
 	}
@@ -247,11 +247,10 @@ func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 	node.LongName = prefix + "-" + c.Config.Name + "-" + nodeName
 	node.Fqdn = nodeName + "." + c.Config.Name + ".io"
 	node.LabDir = c.Dir.Lab + "/" + nodeName
-	// node.CertDir = c.Dir.LabCA + "/" + dutName
 	node.Index = idx
 
 	// initialize the node with global parameters
-	// Kind initialization is either coming from dut_specific or from global
+	// Kind initialization is either coming from `topology.nodes` section or from `topology.defaults`
 	// normalize the data to lower case to compare
 	node.Kind = strings.ToLower(c.kindInitialization(&nodeCfg))
 	switch node.Kind {
@@ -423,7 +422,7 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 		}
 	}
 	if endpoint.Node == nil {
-		log.Fatalf("Not all nodes are specified in the duts section or the names don't match in the duts/endpoint section: %s", nName)
+		log.Fatalf("Not all nodes are specified in the 'topology.nodes' section or the names don't match in the 'links.endpoints' section: %s", nName)
 	}
 
 	// initialize the endpoint name based on the split function

--- a/clab/config.go
+++ b/clab/config.go
@@ -52,9 +52,9 @@ type link struct {
 	Labels    map[string]string `yaml:"labels,omitempty"`
 }
 
-// Conf holds the configuration file input
+// Conf defines lab configuration as it is provided in the YAML file
 type Conf struct {
-	Prefix      string     `yaml:"Prefix"`
+	Name        string
 	DockerInfo  dockerInfo `yaml:"Docker_info"`
 	ClientImage string     `yaml:"Client_image"`
 	Duts        struct {
@@ -150,7 +150,7 @@ func (c *cLab) parseIPInfo() error {
 // ParseTopology parses the lab topology
 func (c *cLab) ParseTopology() error {
 	log.Info("Parsing topology information ...")
-	log.Debugf("Prefix: %s", c.Conf.Prefix)
+	log.Debugf("Prefix: %s", c.Conf.Name)
 	// initialize DockerInfo
 	err := c.parseIPInfo()
 	if err != nil {
@@ -163,7 +163,7 @@ func (c *cLab) ParseTopology() error {
 	}
 
 	c.Dir = new(cLabDirectory)
-	c.Dir.Lab = c.Conf.ConfigPath + "/" + prefix + "-" + c.Conf.Prefix
+	c.Dir.Lab = c.Conf.ConfigPath + "/" + prefix + "-" + c.Conf.Name
 	c.Dir.LabCA = c.Dir.Lab + "/" + "ca"
 	c.Dir.LabCARoot = c.Dir.LabCA + "/" + "root"
 	c.Dir.LabGraph = c.Dir.Lab + "/" + "graph"
@@ -253,8 +253,8 @@ func (c *cLab) NewNode(dutName string, dut dutInfo, idx int) {
 	// initialize a new node
 	node := new(Node)
 	node.ShortName = dutName
-	node.LongName = prefix + "-" + c.Conf.Prefix + "-" + dutName
-	node.Fqdn = dutName + "." + c.Conf.Prefix + ".io"
+	node.LongName = prefix + "-" + c.Conf.Name + "-" + dutName
+	node.Fqdn = dutName + "." + c.Conf.Name + ".io"
 	node.LabDir = c.Dir.Lab + "/" + dutName
 	// node.CertDir = c.Dir.LabCA + "/" + dutName
 	node.Index = idx
@@ -439,7 +439,7 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 		if _, err := netlink.LinkByName(nName); err != nil {
 			log.Fatalf("Bridge %s is referenced in the endpoints section but was not found in the default network namespace", nName)
 		}
-		endpoint.EndpointName = c.Conf.Prefix + epName
+		endpoint.EndpointName = c.Conf.Name + epName
 	} else {
 		endpoint.EndpointName = epName
 	}

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -144,8 +144,8 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	labels := map[string]string{
-		"containerlab":         "lab-" + c.Conf.Prefix,
-		"lab-" + c.Conf.Prefix: node.ShortName,
+		"containerlab":       "lab-" + c.Conf.Name,
+		"lab-" + c.Conf.Name: node.ShortName,
 	}
 	if node.Kind != "" {
 		labels["kind"] = node.Kind

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -27,12 +27,10 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 	log.Info("Creating docker bridge")
 
 	ipamIPv4Config := network.IPAMConfig{
-		Subnet:  c.Conf.DockerInfo.Ipv4Subnet,
-		Gateway: c.Conf.DockerInfo.Ipv4Gateway,
+		Subnet: c.Conf.Mgmt.Ipv4Subnet,
 	}
 	ipamIPv6Config := network.IPAMConfig{
-		Subnet:  c.Conf.DockerInfo.Ipv6Subnet,
-		Gateway: c.Conf.DockerInfo.Ipv6Gateway,
+		Subnet: c.Conf.Mgmt.Ipv6Subnet,
 	}
 	var ipamConfig []network.IPAMConfig
 	ipamConfig = append(ipamConfig, ipamIPv4Config)
@@ -59,13 +57,13 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 	var netCreateResponse types.NetworkCreateResponse
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	netCreateResponse, err = c.DockerClient.NetworkCreate(nctx, c.Conf.DockerInfo.Bridge, networkOptions)
+	netCreateResponse, err = c.DockerClient.NetworkCreate(nctx, c.Conf.Mgmt.Network, networkOptions)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			log.Debugf("Container network %s already exists", c.Conf.DockerInfo.Bridge)
+			log.Debugf("Container network %s already exists", c.Conf.Mgmt.Network)
 			nctx, cancel := context.WithTimeout(ctx, c.timeout)
 			defer cancel()
-			netResource, err := c.DockerClient.NetworkInspect(nctx, c.Conf.DockerInfo.Bridge) //, types.NetworkInspectOptions{})
+			netResource, err := c.DockerClient.NetworkInspect(nctx, c.Conf.Mgmt.Network) //, types.NetworkInspectOptions{})
 			if err != nil {
 				return err
 			}
@@ -84,7 +82,7 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 		}
 		bridgeName = "br-" + netCreateResponse.ID[:12]
 	}
-	log.Debugf("container network %s : bridge name: %s", c.Conf.DockerInfo.Bridge, bridgeName)
+	log.Debugf("container network %s : bridge name: %s", c.Conf.Mgmt.Network, bridgeName)
 
 	log.Debug("Disable RPF check on the docker host")
 	err = setSysctl("net/ipv4/conf/all/rp_filter", 0)
@@ -116,21 +114,21 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 func (c *cLab) DeleteBridge(ctx context.Context) (err error) {
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	nres, err := c.DockerClient.NetworkInspect(ctx, c.Conf.DockerInfo.Bridge)
+	nres, err := c.DockerClient.NetworkInspect(ctx, c.Conf.Mgmt.Network)
 	if err != nil {
 		return err
 	}
 	numEndpoints := len(nres.Containers)
 	if numEndpoints > 0 {
-		log.Warnf("network '%s' has %d active endpoints", c.Conf.DockerInfo.Bridge, numEndpoints)
+		log.Warnf("network '%s' has %d active endpoints", c.Conf.Mgmt.Network, numEndpoints)
 		if c.debug {
 			for _, endp := range nres.Containers {
-				log.Debugf("'%s' is connected to %s", endp.Name, c.Conf.DockerInfo.Bridge)
+				log.Debugf("'%s' is connected to %s", endp.Name, c.Conf.Mgmt.Network)
 			}
 		}
 		return nil
 	}
-	err = c.DockerClient.NetworkRemove(nctx, c.Conf.DockerInfo.Bridge)
+	err = c.DockerClient.NetworkRemove(nctx, c.Conf.Mgmt.Network)
 	if err != nil {
 		return err
 	}
@@ -178,7 +176,7 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 			Binds:       node.Binds,
 			Sysctls:     node.Sysctls,
 			Privileged:  true,
-			NetworkMode: container.NetworkMode(c.Conf.DockerInfo.Bridge),
+			NetworkMode: container.NetworkMode(c.Conf.Mgmt.Network),
 		}, nil, node.LongName)
 	if err != nil {
 		return err

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -27,10 +27,10 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 	log.Info("Creating docker bridge")
 
 	ipamIPv4Config := network.IPAMConfig{
-		Subnet: c.Conf.Mgmt.Ipv4Subnet,
+		Subnet: c.Config.Mgmt.Ipv4Subnet,
 	}
 	ipamIPv6Config := network.IPAMConfig{
-		Subnet: c.Conf.Mgmt.Ipv6Subnet,
+		Subnet: c.Config.Mgmt.Ipv6Subnet,
 	}
 	var ipamConfig []network.IPAMConfig
 	ipamConfig = append(ipamConfig, ipamIPv4Config)
@@ -57,13 +57,13 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 	var netCreateResponse types.NetworkCreateResponse
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	netCreateResponse, err = c.DockerClient.NetworkCreate(nctx, c.Conf.Mgmt.Network, networkOptions)
+	netCreateResponse, err = c.DockerClient.NetworkCreate(nctx, c.Config.Mgmt.Network, networkOptions)
 	if err != nil {
 		if strings.Contains(err.Error(), "already exists") {
-			log.Debugf("Container network %s already exists", c.Conf.Mgmt.Network)
+			log.Debugf("Container network %s already exists", c.Config.Mgmt.Network)
 			nctx, cancel := context.WithTimeout(ctx, c.timeout)
 			defer cancel()
-			netResource, err := c.DockerClient.NetworkInspect(nctx, c.Conf.Mgmt.Network) //, types.NetworkInspectOptions{})
+			netResource, err := c.DockerClient.NetworkInspect(nctx, c.Config.Mgmt.Network) //, types.NetworkInspectOptions{})
 			if err != nil {
 				return err
 			}
@@ -82,7 +82,7 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 		}
 		bridgeName = "br-" + netCreateResponse.ID[:12]
 	}
-	log.Debugf("container network %s : bridge name: %s", c.Conf.Mgmt.Network, bridgeName)
+	log.Debugf("container network %s : bridge name: %s", c.Config.Mgmt.Network, bridgeName)
 
 	log.Debug("Disable RPF check on the docker host")
 	err = setSysctl("net/ipv4/conf/all/rp_filter", 0)
@@ -114,21 +114,21 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 func (c *cLab) DeleteBridge(ctx context.Context) (err error) {
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
-	nres, err := c.DockerClient.NetworkInspect(ctx, c.Conf.Mgmt.Network)
+	nres, err := c.DockerClient.NetworkInspect(ctx, c.Config.Mgmt.Network)
 	if err != nil {
 		return err
 	}
 	numEndpoints := len(nres.Containers)
 	if numEndpoints > 0 {
-		log.Warnf("network '%s' has %d active endpoints", c.Conf.Mgmt.Network, numEndpoints)
+		log.Warnf("network '%s' has %d active endpoints", c.Config.Mgmt.Network, numEndpoints)
 		if c.debug {
 			for _, endp := range nres.Containers {
-				log.Debugf("'%s' is connected to %s", endp.Name, c.Conf.Mgmt.Network)
+				log.Debugf("'%s' is connected to %s", endp.Name, c.Config.Mgmt.Network)
 			}
 		}
 		return nil
 	}
-	err = c.DockerClient.NetworkRemove(nctx, c.Conf.Mgmt.Network)
+	err = c.DockerClient.NetworkRemove(nctx, c.Config.Mgmt.Network)
 	if err != nil {
 		return err
 	}
@@ -142,8 +142,8 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	labels := map[string]string{
-		"containerlab":       "lab-" + c.Conf.Name,
-		"lab-" + c.Conf.Name: node.ShortName,
+		"containerlab":         "lab-" + c.Config.Name,
+		"lab-" + c.Config.Name: node.ShortName,
 	}
 	if node.Kind != "" {
 		labels["kind"] = node.Kind
@@ -176,7 +176,7 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 			Binds:       node.Binds,
 			Sysctls:     node.Sysctls,
 			Privileged:  true,
-			NetworkMode: container.NetworkMode(c.Conf.Mgmt.Network),
+			NetworkMode: container.NetworkMode(c.Config.Mgmt.Network),
 		}, nil, node.LongName)
 	if err != nil {
 		return err

--- a/clab/file.go
+++ b/clab/file.go
@@ -14,47 +14,36 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// File type is a struct which define parameter of the topology file
-type File struct {
-	file      string
-	name      string
-	shortname string
+// TopoFile type is a struct which defines parameters of the topology file
+type TopoFile struct {
+	fullName string // file name with extension
+	name     string // file name without extension
 }
 
-// GetTopology gets the lab topology information
-func (c *cLab) GetTopology(topo *string) error {
-	log.Info("Getting topology information ...")
-	log.Debug("Topofile ", *topo)
+// GetTopology parses the topology file into c.Conf structure
+// as well as populates the TopoFile structure with the topology file related information
+func (c *cLab) GetTopology(topo string) error {
+	log.Infof("Getting topology information from %s file...", topo)
 
-	yamlFile, err := ioutil.ReadFile(*topo)
+	yamlFile, err := ioutil.ReadFile(topo)
 	if err != nil {
 		return err
 	}
-	log.Debug(fmt.Sprintf("File contents:\n%s\n", yamlFile))
+	log.Debug(fmt.Sprintf("Topology file contents:\n%s\n", yamlFile))
 
 	err = yaml.Unmarshal(yamlFile, c.Conf)
 	if err != nil {
 		return err
 	}
 
-	s := strings.Split(*topo, "/")
+	s := strings.Split(topo, "/")
 	file := s[len(s)-1]
 	filename := strings.Split(file, ".")
-	sf := strings.Split(filename[0], "-")
-	shortname := ""
-	for _, f := range sf {
-		shortname += f
+	c.TopoFile = &TopoFile{
+		fullName: file,
+		name:     filename[0],
 	}
-	log.Debug(s, file, filename, shortname)
-	c.FileInfo = &File{
-		file:      file,
-		name:      filename[0],
-		shortname: shortname,
-	}
-	log.Debug("File : ", c.FileInfo)
-
 	return nil
-
 }
 
 func fileExists(filename string) bool {
@@ -197,7 +186,6 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 
 	return nil
 }
-
 
 // GenerateConfig generates configuration for the duts
 func (node *Node) generateConfig(dst string) error {

--- a/clab/file.go
+++ b/clab/file.go
@@ -148,7 +148,7 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 		}
 		log.Debugf("CopyFile src %s -> dst %s succeeded", src, dst)
 
-		// create dut directory in lab
+		// create node directory in lab
 		CreateDirectory(node.LabDir, 0777)
 		// generate SRL topology file
 		err = generateSRLTopologyFile(node.Topology, node.LabDir, node.Index)
@@ -187,7 +187,7 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 	return nil
 }
 
-// GenerateConfig generates configuration for the duts
+// GenerateConfig generates configuration for the nodes
 func (node *Node) generateConfig(dst string) error {
 	tpl, err := template.New("srlconfig.tpl").ParseFiles("/etc/containerlab/templates/srl/srlconfig.tpl")
 	if err != nil {

--- a/clab/file.go
+++ b/clab/file.go
@@ -31,7 +31,7 @@ func (c *cLab) GetTopology(topo string) error {
 	}
 	log.Debug(fmt.Sprintf("Topology file contents:\n%s\n", yamlFile))
 
-	err = yaml.Unmarshal(yamlFile, c.Conf)
+	err = yaml.Unmarshal(yamlFile, c.Config)
 	if err != nil {
 		return err
 	}

--- a/clab/graph.go
+++ b/clab/graph.go
@@ -15,7 +15,7 @@ var g *gographviz.Graph
 func (c *cLab) GenerateGraph(topo string) error {
 	log.Info("Generating lab graph ...")
 	g = gographviz.NewGraph()
-	if err := g.SetName(c.FileInfo.shortname); err != nil {
+	if err := g.SetName(c.TopoFile.name); err != nil {
 		return err
 	}
 	if err := g.SetDir(false); err != nil {
@@ -45,7 +45,7 @@ func (c *cLab) GenerateGraph(topo string) error {
 			attr["fontcolor"] = "black"
 		}
 
-		if err := g.AddNode(c.FileInfo.shortname, node.ShortName, attr); err != nil {
+		if err := g.AddNode(c.TopoFile.name, node.ShortName, attr); err != nil {
 			return err
 		}
 
@@ -70,11 +70,11 @@ func (c *cLab) GenerateGraph(topo string) error {
 	CreateDirectory(c.Dir.LabGraph, 0755)
 
 	// create graph filename
-	dotfile := c.Dir.LabGraph + "/" + c.FileInfo.name + ".dot"
+	dotfile := c.Dir.LabGraph + "/" + c.TopoFile.name + ".dot"
 	createFile(dotfile, g.String())
 	log.Info("Created", dotfile, "!")
 
-	pngfile := c.Dir.LabGraph + "/" + c.FileInfo.name + ".png"
+	pngfile := c.Dir.LabGraph + "/" + c.TopoFile.name + ".png"
 
 	// Only try to create png
 	if commandExists("dot") {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,13 +17,8 @@ import (
 	"github.com/srl-wim/container-lab/clab"
 )
 
-// path to the topology file
-var topo string
-var graph bool
-
 // name of the container management network
 var mgmtNetName string
-var prefix string
 
 // IPv4/6 address range for container management network
 var mgmtIPv4Subnet net.IPNet

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -59,7 +59,7 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to parse rootCACsrTemplate: %v", err)
 		}
-		rootCerts, err := c.GenerateRootCa(tpl, clab.CaRootInput{Prefix: c.Conf.Prefix})
+		rootCerts, err := c.GenerateRootCa(tpl, clab.CaRootInput{Prefix: c.Conf.Name})
 		if err != nil {
 			return fmt.Errorf("failed to generate rootCa: %v", err)
 		}
@@ -130,7 +130,7 @@ var deployCmd = &cobra.Command{
 		// show topology output
 
 		// print table summary
-		labels = append(labels, "containerlab=lab-"+c.Conf.Prefix)
+		labels = append(labels, "containerlab=lab-"+c.Conf.Name)
 		containers, err := c.ListContainers(ctx, labels)
 		if err != nil {
 			return fmt.Errorf("could not list containers: %v", err)
@@ -158,7 +158,7 @@ func init() {
 
 func setFlags(conf *clab.Conf) {
 	if prefix != "" {
-		conf.Prefix = prefix
+		conf.Name = prefix
 	}
 	if mgmtNetName != "" {
 		conf.DockerInfo.Bridge = mgmtNetName

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -37,7 +37,7 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 
-		if err = c.GetTopology(&topo); err != nil {
+		if err = c.GetTopology(topo); err != nil {
 			return err
 		}
 		setFlags(c.Conf)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -20,10 +20,14 @@ import (
 // path to the topology file
 var topo string
 var graph bool
-var bridge string
+
+// name of the container management network
+var mgmtNetName string
 var prefix string
-var ipv4Subnet net.IPNet
-var ipv6Subnet net.IPNet
+
+// IPv4/6 address range for container management network
+var mgmtIPv4Subnet net.IPNet
+var mgmtIPv6Subnet net.IPNet
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
@@ -152,23 +156,23 @@ var deployCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(deployCmd)
 	deployCmd.Flags().BoolVarP(&graph, "graph", "g", false, "generate topology graph")
-	deployCmd.Flags().StringVarP(&bridge, "bridge", "b", "", "docker network name for management")
-	deployCmd.Flags().IPNetVarP(&ipv4Subnet, "ipv4-subnet", "4", net.IPNet{}, "management network IPv4 subnet range")
-	deployCmd.Flags().IPNetVarP(&ipv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
+	deployCmd.Flags().StringVarP(&mgmtNetName, "network", "n", "", "management network name")
+	deployCmd.Flags().IPNetVarP(&mgmtIPv4Subnet, "ipv4-subnet", "4", net.IPNet{}, "management network IPv4 subnet range")
+	deployCmd.Flags().IPNetVarP(&mgmtIPv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
 }
 
 func setFlags(conf *clab.Conf) {
 	if prefix != "" {
 		conf.Prefix = prefix
 	}
-	if bridge != "" {
-		conf.DockerInfo.Bridge = bridge
+	if mgmtNetName != "" {
+		conf.DockerInfo.Bridge = mgmtNetName
 	}
-	if ipv4Subnet.String() != "<nil>" {
-		conf.DockerInfo.Ipv4Subnet = ipv4Subnet.String()
+	if mgmtIPv4Subnet.String() != "<nil>" {
+		conf.DockerInfo.Ipv4Subnet = mgmtIPv4Subnet.String()
 	}
-	if ipv6Subnet.String() != "<nil>" {
-		conf.DockerInfo.Ipv6Subnet = ipv6Subnet.String()
+	if mgmtIPv6Subnet.String() != "<nil>" {
+		conf.DockerInfo.Ipv6Subnet = mgmtIPv6Subnet.String()
 	}
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -40,8 +40,8 @@ var deployCmd = &cobra.Command{
 		if err = c.GetTopology(topo); err != nil {
 			return err
 		}
-		setFlags(c.Conf)
-		log.Debugf("lab Conf: %+v", c.Conf)
+		setFlags(c.Config)
+		log.Debugf("lab Conf: %+v", c.Config)
 		// Parse topology information
 		if err = c.ParseTopology(); err != nil {
 			return err
@@ -59,7 +59,7 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to parse rootCACsrTemplate: %v", err)
 		}
-		rootCerts, err := c.GenerateRootCa(tpl, clab.CaRootInput{Prefix: c.Conf.Name})
+		rootCerts, err := c.GenerateRootCa(tpl, clab.CaRootInput{Prefix: c.Config.Name})
 		if err != nil {
 			return fmt.Errorf("failed to generate rootCa: %v", err)
 		}
@@ -130,7 +130,7 @@ var deployCmd = &cobra.Command{
 		// show topology output
 
 		// print table summary
-		labels = append(labels, "containerlab=lab-"+c.Conf.Name)
+		labels = append(labels, "containerlab=lab-"+c.Config.Name)
 		containers, err := c.ListContainers(ctx, labels)
 		if err != nil {
 			return fmt.Errorf("could not list containers: %v", err)
@@ -139,11 +139,11 @@ var deployCmd = &cobra.Command{
 			return fmt.Errorf("no containers found")
 		}
 		log.Info("Writing /etc/hosts file")
-		err = createHostsFile(containers, c.Conf.Mgmt.Network)
+		err = createHostsFile(containers, c.Config.Mgmt.Network)
 		if err != nil {
 			log.Errorf("failed to create hosts file: %v", err)
 		}
-		printContainerInspect(containers, c.Conf.Mgmt.Network, format)
+		printContainerInspect(containers, c.Config.Mgmt.Network, format)
 		return nil
 	},
 }
@@ -156,7 +156,7 @@ func init() {
 	deployCmd.Flags().IPNetVarP(&mgmtIPv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
 }
 
-func setFlags(conf *clab.Conf) {
+func setFlags(conf *clab.Config) {
 	if prefix != "" {
 		conf.Name = prefix
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -139,11 +139,11 @@ var deployCmd = &cobra.Command{
 			return fmt.Errorf("no containers found")
 		}
 		log.Info("Writing /etc/hosts file")
-		err = createHostsFile(containers, c.Conf.DockerInfo.Bridge)
+		err = createHostsFile(containers, c.Conf.Mgmt.Network)
 		if err != nil {
 			log.Errorf("failed to create hosts file: %v", err)
 		}
-		printContainerInspect(containers, c.Conf.DockerInfo.Bridge, format)
+		printContainerInspect(containers, c.Conf.Mgmt.Network, format)
 		return nil
 	},
 }
@@ -161,13 +161,13 @@ func setFlags(conf *clab.Conf) {
 		conf.Name = prefix
 	}
 	if mgmtNetName != "" {
-		conf.DockerInfo.Bridge = mgmtNetName
+		conf.Mgmt.Network = mgmtNetName
 	}
 	if mgmtIPv4Subnet.String() != "<nil>" {
-		conf.DockerInfo.Ipv4Subnet = mgmtIPv4Subnet.String()
+		conf.Mgmt.Ipv4Subnet = mgmtIPv4Subnet.String()
 	}
 	if mgmtIPv6Subnet.String() != "<nil>" {
-		conf.DockerInfo.Ipv6Subnet = mgmtIPv6Subnet.String()
+		conf.Mgmt.Ipv6Subnet = mgmtIPv6Subnet.String()
 	}
 }
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -29,7 +29,7 @@ var destroyCmd = &cobra.Command{
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		if err = c.GetTopology(&topo); err != nil {
+		if err = c.GetTopology(topo); err != nil {
 			return err
 		}
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -38,7 +38,7 @@ var destroyCmd = &cobra.Command{
 			return err
 		}
 
-		containers, err := c.ListContainers(ctx, []string{fmt.Sprintf("containerlab=lab-%s", c.Conf.Prefix)})
+		containers, err := c.ListContainers(ctx, []string{fmt.Sprintf("containerlab=lab-%s", c.Conf.Name)})
 		if err != nil {
 			return fmt.Errorf("could not list containers: %v", err)
 		}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -62,7 +62,7 @@ var destroyCmd = &cobra.Command{
 		}
 		wg.Wait()
 		log.Info("Removing container entries from /etc/hosts file")
-		err = deleteEntriesFromHostsFile(containers, c.Conf.DockerInfo.Bridge)
+		err = deleteEntriesFromHostsFile(containers, c.Conf.Mgmt.Network)
 		if err != nil {
 			return err
 		}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -38,7 +38,7 @@ var destroyCmd = &cobra.Command{
 			return err
 		}
 
-		containers, err := c.ListContainers(ctx, []string{fmt.Sprintf("containerlab=lab-%s", c.Conf.Name)})
+		containers, err := c.ListContainers(ctx, []string{fmt.Sprintf("containerlab=lab-%s", c.Config.Name)})
 		if err != nil {
 			return fmt.Errorf("could not list containers: %v", err)
 		}
@@ -62,7 +62,7 @@ var destroyCmd = &cobra.Command{
 		}
 		wg.Wait()
 		log.Info("Removing container entries from /etc/hosts file")
-		err = deleteEntriesFromHostsFile(containers, c.Conf.Mgmt.Network)
+		err = deleteEntriesFromHostsFile(containers, c.Config.Mgmt.Network)
 		if err != nil {
 			return err
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -36,7 +36,7 @@ var execCmd = &cobra.Command{
 			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
-			prefix = c.Conf.Name
+			prefix = c.Config.Name
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -33,7 +33,7 @@ var execCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		if prefix == "" {
-			if err = c.GetTopology(&topo); err != nil {
+			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
 			prefix = c.Conf.Prefix

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -36,7 +36,7 @@ var execCmd = &cobra.Command{
 			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
-			prefix = c.Conf.Prefix
+			prefix = c.Conf.Name
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -18,7 +18,7 @@ var graphCmd = &cobra.Command{
 			log.Info(err)
 		}
 
-		if err = c.GetTopology(&topo); err != nil {
+		if err = c.GetTopology(topo); err != nil {
 			log.Fatal(err)
 		}
 

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -69,7 +69,7 @@ var inspectCmd = &cobra.Command{
 			fmt.Println(string(b))
 			return
 		}
-		printContainerInspect(containers, c.Conf.DockerInfo.Bridge, format)
+		printContainerInspect(containers, c.Conf.Mgmt.Network, format)
 	},
 }
 

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -45,7 +45,7 @@ var inspectCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		if prefix == "" {
-			if err = c.GetTopology(&topo); err != nil {
+			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
 			prefix = c.Conf.Prefix

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -48,7 +48,7 @@ var inspectCmd = &cobra.Command{
 			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
-			prefix = c.Conf.Name
+			prefix = c.Config.Name
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -69,7 +69,7 @@ var inspectCmd = &cobra.Command{
 			fmt.Println(string(b))
 			return
 		}
-		printContainerInspect(containers, c.Conf.Mgmt.Network, format)
+		printContainerInspect(containers, c.Config.Mgmt.Network, format)
 	},
 }
 

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -48,7 +48,7 @@ var inspectCmd = &cobra.Command{
 			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
-			prefix = c.Conf.Prefix
+			prefix = c.Conf.Name
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,13 @@ const (
 var debug bool
 var timeout time.Duration
 
+// path to the topology file
+var topo string
+var graph bool
+
+// lab prefix
+var prefix string
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "containerlab",

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -27,7 +27,7 @@ var saveCmd = &cobra.Command{
 			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
-			prefix = c.Conf.Prefix
+			prefix = c.Conf.Name
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -24,7 +24,7 @@ var saveCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 		if prefix == "" {
-			if err = c.GetTopology(&topo); err != nil {
+			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
 			prefix = c.Conf.Prefix

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -27,7 +27,7 @@ var saveCmd = &cobra.Command{
 			if err = c.GetTopology(topo); err != nil {
 				log.Fatal(err)
 			}
-			prefix = c.Conf.Name
+			prefix = c.Config.Name
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/lab-examples/br01/br01.yml
+++ b/lab-examples/br01/br01.yml
@@ -1,23 +1,24 @@
 # topology documentation: http://containerlab.srlinux.dev/lab-examples/ext-bridge/
-Prefix: br01
+name: br01
 
-Duts:
-  kind_defaults:
+topology:
+  kinds:
     srl:
       type: ixrd1
       image: srlinux
       license: license.key
-  dut_specifics:
+  nodes:
     srl1:
       kind: srl
     srl2:
       kind: srl
     srl3:
       kind: srl
+    # note, that the bridge br-clab must be created manually
     br-clab:
       kind: bridge
 
-Links:
+links:
   - endpoints: ["srl1:e1-1", "br-clab:eth1"]
   - endpoints: ["srl2:e1-1", "br-clab:eth2"]
   - endpoints: ["srl3:e1-1", "br-clab:eth3"]

--- a/lab-examples/clos01/clos01.yml
+++ b/lab-examples/clos01/clos01.yml
@@ -1,14 +1,14 @@
 # topology documentation: http://containerlab.srlinux.dev/lab-examples/min-clos/
-Prefix: clos01
+name: clos01
 
-Duts:
-  kind_defaults:
+topology:
+  kinds:
     srl:
       image: srlinux
       license: license.key
     linux:
       image: ghcr.io/hellt/network-multitool
-  dut_specifics:
+  nodes:
     leaf1:
       kind: srl
       type: ixrd1
@@ -23,7 +23,7 @@ Duts:
     client2:
       kind: linux
 
-Links:
+links:
   - endpoints: ["leaf1:e1-1", "spine:e1-1"]
   - endpoints: ["leaf2:e1-1", "spine:e1-2"]
   - endpoints: ["client1:eth1", "leaf1:e1-2"]

--- a/lab-examples/clos02/clos02.yml
+++ b/lab-examples/clos02/clos02.yml
@@ -1,14 +1,14 @@
 # topology documentation: http://containerlab.srlinux.dev/lab-examples/min-5clos/
-Prefix: clos02
+name: clos02
 
-Duts:
-  kind_defaults:
+topology:
+  kinds:
     srl:
       image: srlinux
       license: license.key
     linux:
       image: ghcr.io/hellt/network-multitool
-  dut_specifics:
+  nodes:
     leaf1:
       kind: srl
       type: ixrd1
@@ -51,7 +51,7 @@ Duts:
     client4:
       kind: linux
 
-Links:
+links:
   # leaf to spine links POD1
   - endpoints: ["leaf1:e1-1", "spine1:e1-1"]
   - endpoints: ["leaf1:e1-2", "spine2:e1-1"]

--- a/lab-examples/srl01/srl01.yml
+++ b/lab-examples/srl01/srl01.yml
@@ -1,12 +1,12 @@
 # topology documentation: http://containerlab.srlinux.dev/lab-examples/single-srl/
-Prefix: srl01
+name: srl01
 
-Duts:
-  kind_defaults:
+topology:
+  kinds:
     srl:
       type: ixr6
       image: srlinux
       license: license.key
-  dut_specifics:
+  nodes:
     srl:
       kind: srl

--- a/lab-examples/srl02/srl02.yml
+++ b/lab-examples/srl02/srl02.yml
@@ -1,17 +1,17 @@
 # topology documentation: http://containerlab.srlinux.dev/lab-examples/two-srls/
-Prefix: srl02
+name: srl02
 
-Duts:
-  kind_defaults:
+topology:
+  kinds:
     srl:
       type: ixr6
       image: srlinux
       license: license.key
-  dut_specifics:
+  nodes:
     srl1:
       kind: srl
     srl2:
       kind: srl
 
-Links:
+links:
   - endpoints: ["srl1:e1-1", "srl2:e1-1"]

--- a/lab-examples/srl03/srl03.yml
+++ b/lab-examples/srl03/srl03.yml
@@ -1,14 +1,14 @@
-Prefix: srl03
+name: srl03
 
-Duts:
-  kind_defaults:
+topology:
+  kinds:
     srl:
       type: ixr6
       image: srlinux
       license: license.key
     linux:
       image: ghcr.io/hellt/network-multitool
-  dut_specifics:
+  nodes:
     wan1:
       kind: srl
     wan2:
@@ -26,7 +26,7 @@ Duts:
     client4:
       kind: "linux"
 
-Links:
+links:
   # wan1 <-> wan2 connections
   - endpoints: ["wan1:e1-1", "wan2:e1-1"]
   - endpoints: ["wan1:e1-2", "wan2:e1-2"]

--- a/lab-examples/srlceos01/srlceos01.yml
+++ b/lab-examples/srlceos01/srlceos01.yml
@@ -1,8 +1,8 @@
 # topology documentation: http://containerlab.srlinux.dev/lab-examples/srl-ceos/
-Prefix: srlceos01
+name: srlceos01
 
-Duts:
-  dut_specifics:
+topology:
+  nodes:
     srl:
       kind: srl
       type: ixrd2
@@ -12,5 +12,5 @@ Duts:
       kind: ceos
       image: ceos
 
-Links:
+links:
   - endpoints: ["srl:e1-1", "ceos:eth1"]


### PR DESCRIPTION
This PR will be in Draft whilist it undergoes development. The changes will appear hear, I will try to keep commits per sub-feature to make the review easier

1. renamed flag to provide docker network name (from `--bridge <name>` to `--network <name>`) 8c48f50
2. moved flag variables that are defined in root.cmd from config.go b07a8d1
3. Added comment clarifying the role of `cLab.Init()` in b7d42d2
4. reworked `GetTopology` (removed shortname for files, renamed File struct to TopoFile) in 3ad1543
5. renamed cLab.Prefix to cLab.name (5b0b5e0)
6. renamed docker_info section to `mgmt` section. Also removed ipv4/6 gateway calculation, since it will be used by docker automatically as a GW in the management network (1fec139)
7. renamed `duts` config element to `topology` with a nested structure of 
    ```
    type Topology struct {
       	    Defaults NodeConfig
	    Kinds    map[string]NodeConfig
	    Nodes    map[string]NodeConfig
    }
    ```
8. renamed lab examples topologies in ac98ce9
9. renamed `dut` vars/strings to nodeCfg or node accordingly. ( d9e6404)
closes #97 