### PR TITLE
check bridge exist in a separate function

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -1,6 +1,7 @@
 package clab
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -436,9 +437,6 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 
 	// initialize the endpoint name based on the split function
 	if c.Nodes[nName].Kind == "bridge" {
-		if _, err := netlink.LinkByName(nName); err != nil {
-			log.Fatalf("Bridge %s is referenced in the endpoints section but was not found in the default network namespace", nName)
-		}
 		endpoint.EndpointName = c.Conf.Prefix + epName
 	} else {
 		endpoint.EndpointName = epName
@@ -447,4 +445,16 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 		log.Fatalf("interface '%s' name exceeds maximum length of 15 characters", endpoint.EndpointName)
 	}
 	return endpoint
+}
+
+// VerifyBridgeExists verifies if every node of kind=bridge exists on the lab host
+func (c *cLab) VerifyBridgesExist() error {
+	for name, node := range c.Nodes {
+		if node.Kind == "bridge" {
+			if _, err := netlink.LinkByName(name); err != nil {
+				return fmt.Errorf("Bridge %s is referenced in the endpoints section but was not found in the default network namespace", name)
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -48,6 +48,10 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 
+		if err = c.VerifyBridgesExist(); err != nil {
+			return err
+		}
+
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/cmd/graph.go
+++ b/cmd/graph.go
@@ -13,21 +13,17 @@ var graphCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		c := clab.NewContainerLab(debug)
-		err := c.Init(timeout)
-		if err != nil {
-			log.Info(err)
-		}
 
-		if err = c.GetTopology(&topo); err != nil {
+		if err := c.GetTopology(&topo); err != nil {
 			log.Fatal(err)
 		}
 
 		// Parse topology information
-		if err = c.ParseTopology(); err != nil {
+		if err := c.ParseTopology(); err != nil {
 			log.Fatal(err)
 		}
 
-		if err = c.GenerateGraph(topo); err != nil {
+		if err := c.GenerateGraph(topo); err != nil {
 			log.Error(err)
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
closes #117 

the check for bridge existence is moved to a separate method of cLab