### PR TITLE
moved links under topology

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -56,6 +56,7 @@ type Topology struct {
 	Defaults NodeConfig
 	Kinds    map[string]NodeConfig
 	Nodes    map[string]NodeConfig
+	Links    []link
 }
 
 type link struct {
@@ -68,7 +69,6 @@ type Config struct {
 	Name       string
 	Mgmt       mgmtNet
 	Topology   Topology
-	Links      []link
 	ConfigPath string `yaml:"config_path"`
 }
 
@@ -169,7 +169,7 @@ func (c *cLab) ParseTopology() error {
 		}
 		idx++
 	}
-	for i, l := range c.Config.Links {
+	for i, l := range c.Config.Topology.Links {
 		// i represents the endpoint integer and l provide the link struct
 		c.Links[i] = c.NewLink(l)
 	}

--- a/lab-examples/br01/br01.yml
+++ b/lab-examples/br01/br01.yml
@@ -18,7 +18,7 @@ topology:
     br-clab:
       kind: bridge
 
-links:
-  - endpoints: ["srl1:e1-1", "br-clab:eth1"]
-  - endpoints: ["srl2:e1-1", "br-clab:eth2"]
-  - endpoints: ["srl3:e1-1", "br-clab:eth3"]
+  links:
+    - endpoints: ["srl1:e1-1", "br-clab:eth1"]
+    - endpoints: ["srl2:e1-1", "br-clab:eth2"]
+    - endpoints: ["srl3:e1-1", "br-clab:eth3"]

--- a/lab-examples/clos01/clos01.yml
+++ b/lab-examples/clos01/clos01.yml
@@ -23,8 +23,8 @@ topology:
     client2:
       kind: linux
 
-links:
-  - endpoints: ["leaf1:e1-1", "spine:e1-1"]
-  - endpoints: ["leaf2:e1-1", "spine:e1-2"]
-  - endpoints: ["client1:eth1", "leaf1:e1-2"]
-  - endpoints: ["client2:eth1", "leaf2:e1-2"]
+  links:
+    - endpoints: ["leaf1:e1-1", "spine:e1-1"]
+    - endpoints: ["leaf2:e1-1", "spine:e1-2"]
+    - endpoints: ["client1:eth1", "leaf1:e1-2"]
+    - endpoints: ["client2:eth1", "leaf2:e1-2"]

--- a/lab-examples/clos02/clos02.yml
+++ b/lab-examples/clos02/clos02.yml
@@ -51,27 +51,27 @@ topology:
     client4:
       kind: linux
 
-links:
-  # leaf to spine links POD1
-  - endpoints: ["leaf1:e1-1", "spine1:e1-1"]
-  - endpoints: ["leaf1:e1-2", "spine2:e1-1"]
-  - endpoints: ["leaf2:e1-1", "spine1:e1-2"]
-  - endpoints: ["leaf2:e1-2", "spine2:e1-2"]
-  # spine to superspine links POD1
-  - endpoints: ["spine1:e1-3", "superspine1:e1-1"]
-  - endpoints: ["spine2:e1-3", "superspine2:e1-1"]
+  links:
+    # leaf to spine links POD1
+    - endpoints: ["leaf1:e1-1", "spine1:e1-1"]
+    - endpoints: ["leaf1:e1-2", "spine2:e1-1"]
+    - endpoints: ["leaf2:e1-1", "spine1:e1-2"]
+    - endpoints: ["leaf2:e1-2", "spine2:e1-2"]
+    # spine to superspine links POD1
+    - endpoints: ["spine1:e1-3", "superspine1:e1-1"]
+    - endpoints: ["spine2:e1-3", "superspine2:e1-1"]
 
-  # leaf to spine links POD2
-  - endpoints: ["leaf3:e1-1", "spine3:e1-1"]
-  - endpoints: ["leaf3:e1-2", "spine4:e1-1"]
-  - endpoints: ["leaf4:e1-1", "spine3:e1-2"]
-  - endpoints: ["leaf4:e1-2", "spine4:e1-2"]
-  # spine to superspine links POD2
-  - endpoints: ["spine3:e1-3", "superspine1:e1-2"]
-  - endpoints: ["spine4:e1-3", "superspine2:e1-2"]
+    # leaf to spine links POD2
+    - endpoints: ["leaf3:e1-1", "spine3:e1-1"]
+    - endpoints: ["leaf3:e1-2", "spine4:e1-1"]
+    - endpoints: ["leaf4:e1-1", "spine3:e1-2"]
+    - endpoints: ["leaf4:e1-2", "spine4:e1-2"]
+    # spine to superspine links POD2
+    - endpoints: ["spine3:e1-3", "superspine1:e1-2"]
+    - endpoints: ["spine4:e1-3", "superspine2:e1-2"]
 
-  # client connection links
-  - endpoints: ["client1:eth1", "leaf1:e1-3"]
-  - endpoints: ["client2:eth1", "leaf2:e1-3"]
-  - endpoints: ["client3:eth1", "leaf3:e1-3"]
-  - endpoints: ["client4:eth1", "leaf4:e1-3"]
+    # client connection links
+    - endpoints: ["client1:eth1", "leaf1:e1-3"]
+    - endpoints: ["client2:eth1", "leaf2:e1-3"]
+    - endpoints: ["client3:eth1", "leaf3:e1-3"]
+    - endpoints: ["client4:eth1", "leaf4:e1-3"]

--- a/lab-examples/srl02/srl02.yml
+++ b/lab-examples/srl02/srl02.yml
@@ -13,5 +13,5 @@ topology:
     srl2:
       kind: srl
 
-links:
-  - endpoints: ["srl1:e1-1", "srl2:e1-1"]
+  links:
+    - endpoints: ["srl1:e1-1", "srl2:e1-1"]

--- a/lab-examples/srl03/srl03.yml
+++ b/lab-examples/srl03/srl03.yml
@@ -26,35 +26,35 @@ topology:
     client4:
       kind: "linux"
 
-links:
-  # wan1 <-> wan2 connections
-  - endpoints: ["wan1:e1-1", "wan2:e1-1"]
-  - endpoints: ["wan1:e1-2", "wan2:e1-2"]
-  - endpoints: ["wan1:e1-3", "wan2:e1-3"]
-  - endpoints: ["wan1:e1-4", "wan2:e1-4"]
+  links:
+    # wan1 <-> wan2 connections
+    - endpoints: ["wan1:e1-1", "wan2:e1-1"]
+    - endpoints: ["wan1:e1-2", "wan2:e1-2"]
+    - endpoints: ["wan1:e1-3", "wan2:e1-3"]
+    - endpoints: ["wan1:e1-4", "wan2:e1-4"]
 
-  # wan1 <-> wan3 connections
-  - endpoints: ["wan1:e1-5", "wan3:e1-1"]
-  - endpoints: ["wan1:e1-6", "wan3:e1-2"]
+    # wan1 <-> wan3 connections
+    - endpoints: ["wan1:e1-5", "wan3:e1-1"]
+    - endpoints: ["wan1:e1-6", "wan3:e1-2"]
 
-  # wan1 <-> wan4 connections
-  - endpoints: ["wan1:e1-7", "wan4:e1-1"]
-  - endpoints: ["wan1:e1-8", "wan4:e1-2"]
+    # wan1 <-> wan4 connections
+    - endpoints: ["wan1:e1-7", "wan4:e1-1"]
+    - endpoints: ["wan1:e1-8", "wan4:e1-2"]
 
-  # wan2 <-> wan3 connections
-  - endpoints: ["wan2:e1-5", "wan3:e1-3"]
-  - endpoints: ["wan2:e1-6", "wan3:e1-4"]
+    # wan2 <-> wan3 connections
+    - endpoints: ["wan2:e1-5", "wan3:e1-3"]
+    - endpoints: ["wan2:e1-6", "wan3:e1-4"]
 
-  # wan2 <-> wan4 connections
-  - endpoints: ["wan2:e1-7", "wan4:e1-3"]
-  - endpoints: ["wan2:e1-8", "wan4:e1-4"]
+    # wan2 <-> wan4 connections
+    - endpoints: ["wan2:e1-7", "wan4:e1-3"]
+    - endpoints: ["wan2:e1-8", "wan4:e1-4"]
 
-  # wan3 <-> wan4 connections
-  - endpoints: ["wan3:e1-5", "wan4:e1-5"]
-  - endpoints: ["wan3:e1-6", "wan4:e1-6"]
+    # wan3 <-> wan4 connections
+    - endpoints: ["wan3:e1-5", "wan4:e1-5"]
+    - endpoints: ["wan3:e1-6", "wan4:e1-6"]
 
-  # client connections
-  - endpoints: ["client1:eth1", "wan1:e1-9"]
-  - endpoints: ["client2:eth1", "wan2:e1-9"]
-  - endpoints: ["client3:eth1", "wan3:e1-7"]
-  - endpoints: ["client4:eth1", "wan4:e1-7"]
+    # client connections
+    - endpoints: ["client1:eth1", "wan1:e1-9"]
+    - endpoints: ["client2:eth1", "wan2:e1-9"]
+    - endpoints: ["client3:eth1", "wan3:e1-7"]
+    - endpoints: ["client4:eth1", "wan4:e1-7"]

--- a/lab-examples/srlceos01/srlceos01.yml
+++ b/lab-examples/srlceos01/srlceos01.yml
@@ -12,5 +12,5 @@ topology:
       kind: ceos
       image: ceos
 
-links:
-  - endpoints: ["srl:e1-1", "ceos:eth1"]
+  links:
+    - endpoints: ["srl:e1-1", "ceos:eth1"]


### PR DESCRIPTION
this is a hot fix for a slipped over bug that did not put `links` under the `topology` section of the Topology Definition File