### PR TITLE
allow user defined mounts for kinds and nodes

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -99,7 +99,6 @@ type Node struct {
 	Cmd       string
 	Env       []string
 	Mounts    map[string]volume
-	Volumes   map[string]struct{}
 	Binds     []string
 
 	TLSCert   string
@@ -342,14 +341,6 @@ func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 		v.ReadOnly = true
 		log.Debug("Topology File: ", v.Source)
 		node.Mounts["topology"] = v
-
-		node.Volumes = make(map[string]struct{})
-		node.Volumes = map[string]struct{}{
-			node.Mounts["license"].Destination:  {},
-			node.Mounts["config"].Destination:   {},
-			node.Mounts["envConf"].Destination:  {},
-			node.Mounts["topology"].Destination: {},
-		}
 
 		bindLicense := node.Mounts["license"].Source + ":" + node.Mounts["license"].Destination + ":" + "ro"
 		bindConfig := node.Mounts["config"].Source + ":" + node.Mounts["config"].Destination + ":" + "rw"

--- a/clab/config.go
+++ b/clab/config.go
@@ -49,7 +49,7 @@ type NodeConfig struct {
 	License  string
 	Position string
 	Cmd      string
-	Mounts   []string // list of bind mount compatible strings
+	Binds    []string // list of bind mount compatible strings
 }
 
 // Topology represents a lab topology
@@ -99,8 +99,7 @@ type Node struct {
 	User      string
 	Cmd       string
 	Env       []string
-	Mounts    []string // Bind mounts strings (src:dest:options)
-	Binds     []string
+	Binds     []string // Bind mounts strings (src:dest:options)
 
 	TLSCert   string
 	TLSKey    string
@@ -183,11 +182,11 @@ func (c *cLab) kindInitialization(nodeCfg *NodeConfig) string {
 	return c.Config.Topology.Defaults.Kind
 }
 
-func (c *cLab) mountsInit(nodeCfg *NodeConfig) []string {
-	if len(nodeCfg.Mounts) != 0 {
-		return nodeCfg.Mounts
+func (c *cLab) bindsInit(nodeCfg *NodeConfig) []string {
+	if len(nodeCfg.Binds) != 0 {
+		return nodeCfg.Binds
 	}
-	return c.Config.Topology.Kinds[nodeCfg.Kind].Mounts
+	return c.Config.Topology.Kinds[nodeCfg.Kind].Binds
 }
 
 func (c *cLab) groupInitialization(nodeCfg *NodeConfig, kind string) string {
@@ -260,7 +259,7 @@ func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 	// Kind initialization is either coming from `topology.nodes` section or from `topology.defaults`
 	// normalize the data to lower case to compare
 	node.Kind = strings.ToLower(c.kindInitialization(&nodeCfg))
-	node.Mounts = c.mountsInit(&nodeCfg)
+	node.Binds = c.bindsInit(&nodeCfg)
 	switch node.Kind {
 	case "ceos":
 		// initialize the global parameters with defaults, can be overwritten later
@@ -330,19 +329,19 @@ func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 		if err != nil {
 			return err
 		}
-		node.Mounts = append(node.Mounts, fmt.Sprint(licPath, ":/opt/srlinux/etc/license.key:ro"))
+		node.Binds = append(node.Binds, fmt.Sprint(licPath, ":/opt/srlinux/etc/license.key:ro"))
 
 		// mount config directory
 		cfgPath := filepath.Join(node.LabDir, "config")
-		node.Mounts = append(node.Mounts, fmt.Sprint(cfgPath, ":/etc/opt/srlinux/:rw"))
+		node.Binds = append(node.Binds, fmt.Sprint(cfgPath, ":/etc/opt/srlinux/:rw"))
 
 		// mount srlinux.conf
 		srlconfPath := filepath.Join(node.LabDir, "srlinux.conf")
-		node.Mounts = append(node.Mounts, fmt.Sprint(srlconfPath, ":/home/admin/.srlinux.conf:rw"))
+		node.Binds = append(node.Binds, fmt.Sprint(srlconfPath, ":/home/admin/.srlinux.conf:rw"))
 
 		// mount srlinux topology
 		topoPath := filepath.Join(node.LabDir, "topology.yml")
-		node.Mounts = append(node.Mounts, fmt.Sprint(topoPath, ":/tmp/topology.yml:ro"))
+		node.Binds = append(node.Binds, fmt.Sprint(topoPath, ":/tmp/topology.yml:ro"))
 
 	case "alpine", "linux":
 		node.Config = c.configInitialization(&nodeCfg, node.Kind)

--- a/clab/config.go
+++ b/clab/config.go
@@ -49,6 +49,7 @@ type NodeConfig struct {
 	License  string
 	Position string
 	Cmd      string
+	Mounts   []string // list of bind mount compatible strings
 }
 
 // Topology represents a lab topology
@@ -182,6 +183,13 @@ func (c *cLab) kindInitialization(nodeCfg *NodeConfig) string {
 	return c.Config.Topology.Defaults.Kind
 }
 
+func (c *cLab) mountsInit(nodeCfg *NodeConfig) []string {
+	if len(nodeCfg.Mounts) != 0 {
+		return nodeCfg.Mounts
+	}
+	return c.Config.Topology.Kinds[nodeCfg.Kind].Mounts
+}
+
 func (c *cLab) groupInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Group != "" {
 		return nodeCfg.Group
@@ -252,6 +260,7 @@ func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 	// Kind initialization is either coming from `topology.nodes` section or from `topology.defaults`
 	// normalize the data to lower case to compare
 	node.Kind = strings.ToLower(c.kindInitialization(&nodeCfg))
+	node.Mounts = c.mountsInit(&nodeCfg)
 	switch node.Kind {
 	case "ceos":
 		// initialize the global parameters with defaults, can be overwritten later

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -168,7 +168,6 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 			AttachStdout: true,
 			AttachStderr: true,
 			Hostname:     node.ShortName,
-			Volumes:      node.Volumes,
 			Tty:          true,
 			User:         node.User,
 			Labels:       labels,

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -172,7 +172,7 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 			User:         node.User,
 			Labels:       labels,
 		}, &container.HostConfig{
-			Binds:       node.Binds,
+			Binds:       node.Mounts,
 			Sysctls:     node.Sysctls,
 			Privileged:  true,
 			NetworkMode: container.NetworkMode(c.Config.Mgmt.Network),

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -172,7 +172,7 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 			User:         node.User,
 			Labels:       labels,
 		}, &container.HostConfig{
-			Binds:       node.Mounts,
+			Binds:       node.Binds,
 			Sysctls:     node.Sysctls,
 			Privileged:  true,
 			NetworkMode: container.NetworkMode(c.Config.Mgmt.Network),


### PR DESCRIPTION
closes #88 

this PR allows users to define Bind Mounts for nodes or kinds. For example:

```yaml
topology:
  kinds:
    srl:
      type: ixr6
      image: srlinux
      license: license.key
      binds:
        - "/tmp/1test:/tmp/bla:ro"
```

or 
```yaml
topology:
  nodes:
    srl:
      kind: srl
      binds:
        - "/tmp/1test:/tmp/bla"
```

The format of bindmount string follows the format of docker/oci.