### PR TITLE
Per node cfg template

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -18,6 +18,8 @@ const (
 	dockerNetName     = "clab"
 	dockerNetIPv4Addr = "172.20.20.0/24"
 	dockerNetIPv6Addr = "2001:172:20:20::/80"
+
+	defaultConfigTemplate = "/etc/containerlab/templates/srl/srlconfig.tpl"
 )
 
 // supported kinds
@@ -203,7 +205,15 @@ func (c *cLab) configInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Config != "" {
 		return nodeCfg.Config
 	}
-	return c.Config.Topology.Kinds[kind].Config
+	if kindConfig, ok := c.Config.Topology.Kinds[kind]; ok {
+		if kindConfig.Config != "" {
+			return kindConfig.Config
+		}
+	}
+	if c.Config.Topology.Defaults.Config != "" {
+		return c.Config.Topology.Defaults.Config
+	}
+	return defaultConfigTemplate
 }
 
 func (c *cLab) imageInitialization(nodeCfg *NodeConfig, kind string) string {

--- a/clab/file.go
+++ b/clab/file.go
@@ -189,7 +189,7 @@ func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
 
 // GenerateConfig generates configuration for the nodes
 func (node *Node) generateConfig(dst string) error {
-	tpl, err := template.New("srlconfig.tpl").ParseFiles("/etc/containerlab/templates/srl/srlconfig.tpl")
+	tpl, err := template.New(fmt.Sprintf("config-template-%s", node.ShortName)).ParseFiles(node.Config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
this PR, allows to specify a per node config template using yaml filed `config` under defaults, kinds or the node itself