### PR TITLE
use timeout from clab when deleting container

### DIFF
--- a/clab/docker.go
+++ b/clab/docker.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -321,9 +320,9 @@ func (c *cLab) Exec(ctx context.Context, id string, cmd []string) ([]byte, []byt
 }
 
 // DeleteContainer tries to stop a container then remove it
-func (c *cLab) DeleteContainer(ctx context.Context, name string, timeout time.Duration) error {
+func (c *cLab) DeleteContainer(ctx context.Context, name string) error {
 	force := false
-	err := c.DockerClient.ContainerStop(ctx, name, &timeout)
+	err := c.DockerClient.ContainerStop(ctx, name, &c.timeout)
 	if err != nil {
 		log.Errorf("could not stop container '%s': %v", name, err)
 		force = true

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	log "github.com/sirupsen/logrus"
@@ -62,7 +61,7 @@ var destroyCmd = &cobra.Command{
 					name = strings.TrimLeft(cont.Names[0], "/")
 				}
 				log.Infof("Stopping container: %s", name)
-				err = c.DeleteContainer(ctx, name, 30*time.Second)
+				err = c.DeleteContainer(ctx, name)
 				if err != nil {
 					log.Errorf("could not remove container '%s': %v", name, err)
 				}


### PR DESCRIPTION
use timeout value set in clab config when deleting containers