### PR TITLE
added port bindings

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -53,7 +53,7 @@ type NodeConfig struct {
 	Position string
 	Cmd      string
 	Binds    []string // list of bind mount compatible strings
-	Ports    []string // list ports to expose
+	Ports    []string // list of port bindings
 }
 
 // Topology represents a lab topology

--- a/clab/config.go
+++ b/clab/config.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/go-connections/nat"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -52,6 +53,7 @@ type NodeConfig struct {
 	Position string
 	Cmd      string
 	Binds    []string // list of bind mount compatible strings
+	Ports    []string // list ports to expose
 }
 
 // Topology represents a lab topology
@@ -83,25 +85,26 @@ type volume struct {
 
 // Node is a struct that contains the information of a container element
 type Node struct {
-	ShortName string
-	LongName  string
-	Fqdn      string
-	LabDir    string
-	Index     int
-	Group     string
-	Kind      string
-	Config    string
-	NodeType  string
-	Position  string
-	License   string
-	Image     string
-	Topology  string
-	EnvConf   string
-	Sysctls   map[string]string
-	User      string
-	Cmd       string
-	Env       []string
-	Binds     []string // Bind mounts strings (src:dest:options)
+	ShortName    string
+	LongName     string
+	Fqdn         string
+	LabDir       string
+	Index        int
+	Group        string
+	Kind         string
+	Config       string
+	NodeType     string
+	Position     string
+	License      string
+	Image        string
+	Topology     string
+	EnvConf      string
+	Sysctls      map[string]string
+	User         string
+	Cmd          string
+	Env          []string
+	Binds        []string    // Bind mounts strings (src:dest:options)
+	PortBindings nat.PortMap // PortBindings define the bindings between the container ports and host ports
 
 	TLSCert   string
 	TLSKey    string
@@ -191,6 +194,18 @@ func (c *cLab) bindsInit(nodeCfg *NodeConfig) []string {
 	return c.Config.Topology.Kinds[nodeCfg.Kind].Binds
 }
 
+// portsInit produces the nat.PortMap out of the slice of string representation of port bindings
+func (c *cLab) portsInit(nodeCfg *NodeConfig) (nat.PortMap, error) {
+	if len(nodeCfg.Ports) != 0 {
+		_, pm, err := nat.ParsePortSpecs(nodeCfg.Ports)
+		if err != nil {
+			return nil, err
+		}
+		return pm, nil
+	}
+	return nil, nil
+}
+
 func (c *cLab) groupInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Group != "" {
 		return nodeCfg.Group
@@ -278,6 +293,13 @@ func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 	// normalize the data to lower case to compare
 	node.Kind = strings.ToLower(c.kindInitialization(&nodeCfg))
 	node.Binds = c.bindsInit(&nodeCfg)
+
+	pb, err := c.portsInit(&nodeCfg)
+	if err != nil {
+		return err
+	}
+	node.PortBindings = pb
+
 	switch node.Kind {
 	case "ceos":
 		// initialize the global parameters with defaults, can be overwritten later

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -171,10 +171,11 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 			User:         node.User,
 			Labels:       labels,
 		}, &container.HostConfig{
-			Binds:       node.Binds,
-			Sysctls:     node.Sysctls,
-			Privileged:  true,
-			NetworkMode: container.NetworkMode(c.Config.Mgmt.Network),
+			Binds:        node.Binds,
+			PortBindings: node.PortBindings,
+			Sysctls:      node.Sysctls,
+			Privileged:   true,
+			NetworkMode:  container.NetworkMode(c.Config.Mgmt.Network),
 		}, nil, node.LongName)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/cloudflare/cfssl v1.4.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
-	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/olekukonko/tablewriter v0.0.4


### PR DESCRIPTION
close #126 

the node now can have a `ports` section which is a list of port binding strings as accepted by docker cli `-p` flag.

example:

```yaml
name: srl01

topology:
  nodes:
    srl:
      kind: srl
      type: ixr6
      image: srlinux
      license: license.key
      ports:
        - 80:8080
        - 55555:43555/udp
        - 55554:43554/tcp

```

the result:
```json
❯ docker inspect clab-srl01-srl -f '{{json .HostConfig.PortBindings}}' | jq
{
  "43554/tcp": [
    {
      "HostIp": "",
      "HostPort": "55554"
    }
  ],
  "43555/udp": [
    {
      "HostIp": "",
      "HostPort": "55555"
    }
  ],
  "8080/tcp": [
    {
      "HostIp": "",
      "HostPort": "80"
    }
  ]
}
```