### PR TITLE
Generate topology file

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -37,8 +37,8 @@ var srlTypes = map[string]string{
 // it is provided via docker network object
 type mgmtNet struct {
 	Network    string // docker network name
-	Ipv4Subnet string `yaml:"ipv4_subnet"`
-	Ipv6Subnet string `yaml:"ipv6_subnet"`
+	Ipv4Subnet string `yaml:"ipv4_subnet,omitempty"`
+	Ipv6Subnet string `yaml:"ipv6_subnet,omitempty"`
 }
 
 // NodeConfig represents a configuration a given node can have in the lab definition file

--- a/clab/config.go
+++ b/clab/config.go
@@ -52,8 +52,8 @@ type NodeConfig struct {
 	License  string   `yaml:"license,omitempty"`
 	Position string   `yaml:"position,omitempty"`
 	Cmd      string   `yaml:"cmd,omitempty"`
-	Binds    []string `yaml:"binds,omitempty"` // list of bind mount compatible strings
-	Ports    []string // list of port bindings
+	Binds    []string `yaml:"binds,omitempty" json:"binds,omitempty"` // list of bind mount compatible strings
+	Ports    []string `yaml:"ports,omitempty"`                        // list of port bindings
 }
 
 // Topology represents a lab topology

--- a/clab/config.go
+++ b/clab/config.go
@@ -226,7 +226,10 @@ func (c *cLab) imageInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Image != "" {
 		return nodeCfg.Image
 	}
-	return c.Config.Topology.Kinds[kind].Image
+	if c.Config.Topology.Kinds[kind].Image != "" {
+		return c.Config.Topology.Kinds[kind].Image
+	}
+	return c.Config.Topology.Defaults.Image
 }
 
 func (c *cLab) licenseInit(nodeCfg *NodeConfig, kind string) (string, error) {

--- a/clab/config.go
+++ b/clab/config.go
@@ -43,23 +43,23 @@ type mgmtNet struct {
 
 // NodeConfig represents a configuration a given node can have in the lab definition file
 type NodeConfig struct {
-	Kind     string
-	Group    string
-	Type     string
-	Config   string
-	Image    string
-	License  string
-	Position string
-	Cmd      string
-	Binds    []string // list of bind mount compatible strings
+	Kind     string   `yaml:"kind,omitempty"`
+	Group    string   `yaml:"group,omitempty"`
+	Type     string   `yaml:"type,omitempty"`
+	Config   string   `yaml:"config,omitempty"`
+	Image    string   `yaml:"image,omitempty"`
+	License  string   `yaml:"license,omitempty"`
+	Position string   `yaml:"position,omitempty"`
+	Cmd      string   `yaml:"cmd,omitempty"`
+	Binds    []string `yaml:"binds,omitempty"` // list of bind mount compatible strings
 }
 
 // Topology represents a lab topology
 type Topology struct {
-	Defaults NodeConfig
-	Kinds    map[string]NodeConfig
-	Nodes    map[string]NodeConfig
-	Links    []LinkConfig
+	Defaults NodeConfig            `yaml:"defaults,omitempty"`
+	Kinds    map[string]NodeConfig `yaml:"kinds,omitempty"`
+	Nodes    map[string]NodeConfig `yaml:"nodes,omitempty"`
+	Links    []LinkConfig          `yaml:"links,omitempty"`
 }
 
 type LinkConfig struct {
@@ -69,10 +69,10 @@ type LinkConfig struct {
 
 // Config defines lab configuration as it is provided in the YAML file
 type Config struct {
-	Name       string
-	Mgmt       mgmtNet
-	Topology   Topology
-	ConfigPath string `yaml:"config_path"`
+	Name       string   `json:"name,omitempty"`
+	Mgmt       mgmtNet  `json:"mgmt,omitempty"`
+	Topology   Topology `json:"topology,omitempty"`
+	ConfigPath string   `yaml:"config_path,omitempty"`
 }
 
 type volume struct {

--- a/clab/config.go
+++ b/clab/config.go
@@ -240,11 +240,21 @@ func (c *cLab) licenseInit(nodeCfg *NodeConfig, kind string) (string, error) {
 		}
 		return lp, nil
 	}
-	lp, err := filepath.Abs(c.Config.Topology.Kinds[kind].License)
-	if err != nil {
-		return "", err
+	if c.Config.Topology.Kinds[kind].License != "" {
+		lp, err := filepath.Abs(c.Config.Topology.Kinds[kind].License)
+		if err != nil {
+			return "", err
+		}
+		return lp, nil
 	}
-	return lp, nil
+	if c.Config.Topology.Defaults.License != "" {
+		lp, err := filepath.Abs(c.Config.Topology.Defaults.License)
+		if err != nil {
+			return "", err
+		}
+		return lp, nil
+	}
+	return "", fmt.Errorf("no license found for node(s) of kind %s", nodeCfg.Kind)
 }
 
 func (c *cLab) cmdInitialization(nodeCfg *NodeConfig, kind string, defCmd string) string {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -42,7 +42,7 @@ func init() {
 	configCmd.AddCommand(configApplyCmd)
 	//
 	configGenerateCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
-	generateCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")
+	configGenerateCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")
 	//
 	configApplyCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
 	configApplyCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -19,7 +19,7 @@ var configCmd = &cobra.Command{
 }
 
 // generateCmd represents the generate command
-var generateCmd = &cobra.Command{
+var configGenerateCmd = &cobra.Command{
 	Use:   "generate",
 	Short: "generate configuration for the lab",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -28,7 +28,7 @@ var generateCmd = &cobra.Command{
 }
 
 // applyCmd represents the apply command
-var applyCmd = &cobra.Command{
+var configApplyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "apply the generated configuration on the lab nodes",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -38,12 +38,12 @@ var applyCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(configCmd)
-	configCmd.AddCommand(generateCmd)
-	configCmd.AddCommand(applyCmd)
+	configCmd.AddCommand(configGenerateCmd)
+	configCmd.AddCommand(configApplyCmd)
 	//
-	generateCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
+	configGenerateCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
 	generateCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")
 	//
-	applyCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
-	applyCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")
+	configApplyCmd.Flags().BoolVarP(&infra, "infra", "", false, "generate infra config")
+	configApplyCmd.Flags().BoolVarP(&workload, "workload", "", false, "generate workloads config")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -119,9 +119,11 @@ var deployCmd = &cobra.Command{
 		}
 		wg.Wait()
 		// cleanup hanging resources if a deployment failed before
+		log.Debug("cleaning up interfaces...")
 		c.InitVirtualWiring()
 		wg = new(sync.WaitGroup)
 		wg.Add(len(c.Links))
+		log.Debug("creating links...")
 		// wire the links between the nodes based on cabling plan
 		for _, link := range c.Links {
 			go func(link *clab.Link) {
@@ -138,10 +140,9 @@ var deployCmd = &cobra.Command{
 				log.Error(err)
 			}
 		}
-
+		log.Debug("containers created, retrieving state and IP addresses...")
 		// show topology output
 
-		// print table summary
 		labels = append(labels, "containerlab=lab-"+c.Config.Name)
 		containers, err := c.ListContainers(ctx, labels)
 		if err != nil {
@@ -155,6 +156,7 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			log.Errorf("failed to create hosts file: %v", err)
 		}
+		// print table summary
 		printContainerInspect(containers, c.Config.Mgmt.Network, format)
 		return nil
 	},

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -158,7 +158,7 @@ func generateTopologyConfig(name, network, ipv4range, ipv6range string, images m
 			config.Topology.Kinds[k] = knd
 			continue
 		}
-		config.Topology.Kinds[k] = clab.NodeConfig{Image: lic}
+		config.Topology.Kinds[k] = clab.NodeConfig{License: lic}
 	}
 	for i := 0; i < numStages-1; i++ {
 		interfaceOffset := uint(0)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -160,6 +160,18 @@ func generateTopologyConfig(name, network, ipv4range, ipv6range string, images m
 		}
 		config.Topology.Kinds[k] = clab.NodeConfig{License: lic}
 	}
+	if numStages == 1 {
+		for j := uint(0); j < nodes[0].numNodes; j++ {
+			node1 := fmt.Sprintf("%s1-%d", nodePrefix, j+1)
+			if _, ok := config.Topology.Nodes[node1]; !ok {
+				config.Topology.Nodes[node1] = clab.NodeConfig{
+					Group: fmt.Sprintf("%s-1", groupPrefix),
+					Kind:  nodes[0].kind,
+					Type:  nodes[0].typ,
+				}
+			}
+		}
+	}
 	for i := 0; i < numStages-1; i++ {
 		interfaceOffset := uint(0)
 		if i > 0 {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -40,7 +40,7 @@ const (
 	defaultGroupPrefix = "group"
 )
 
-var errDuplicatedLicense = errors.New("duplicated license for kind")
+var errDuplicatedLicense = errors.New("duplicated license definition")
 var errSyntax = errors.New("syntax error")
 
 var image string
@@ -175,6 +175,10 @@ func parseLicenseFlag(kind string, license []string) (map[string]string, error) 
 		items := strings.SplitN(lic, ":", 2)
 		switch len(items) {
 		case 1:
+			if kind == "" {
+				log.Errorf("no kind specified for license '%s'", lic)
+				return nil, errSyntax
+			}
 			if _, ok := result[kind]; !ok {
 				result[kind] = items[0]
 			} else {
@@ -215,6 +219,10 @@ func parseNodes(kind string, nodes ...string) ([]nodesDef, error) {
 		def.numNodes = uint(i)
 		switch len(items) {
 		case 1:
+			if kind == "" {
+				log.Errorf("no kind specified for nodes '%s'", n)
+				return nil, errSyntax
+			}
 			def.kind = kind
 			if kind == "srl" {
 				def.typ = defaultSRLType
@@ -227,6 +235,10 @@ func parseNodes(kind string, nodes ...string) ([]nodesDef, error) {
 				def.kind = items[1]
 				def.typ = defaultSRLType
 			default:
+				if kind == "" {
+					log.Errorf("no kind specified for nodes '%s'", n)
+					return nil, errSyntax
+				}
 				def.kind = kind
 				def.typ = items[1]
 			}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -40,7 +40,7 @@ var supportedKinds = []string{"srl", "ceos", "linux", "bridge", "sonic", "crpd"}
 const (
 	defaultSRLType     = "ixr6"
 	defaultNodePrefix  = "node"
-	defaultGroupPrefix = "group"
+	defaultGroupPrefix = "tier"
 )
 
 var errDuplicatedValue = errors.New("duplicated value definition")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -179,7 +179,7 @@ func parseLicenseFlag(kind string, license []string) (map[string]string, error) 
 			if _, ok := result[items[0]]; !ok {
 				result[items[0]] = items[1]
 			} else {
-				return nil, fmt.Errorf("duplicated license for kind '%s'", items[1])
+				return nil, fmt.Errorf("duplicated license for kind '%s'", items[0])
 			}
 		}
 	}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -16,8 +16,12 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/srl-wim/container-lab/clab"
@@ -25,13 +29,29 @@ import (
 )
 
 var interfaceFormat = map[string]string{
-	"srl": "e1-%d",
+	"srl":  "e1-%d",
+	"ceos": "eth%d",
 }
+
+const (
+	defaultSRLType     = "ixr6"
+	defaultNodePrefix  = "node"
+	defaultGroupPrefix = "group"
+)
 
 var image string
 var kind string
-var nodes []uint
-var license string
+var nodes []string
+var license []string
+var nodePrefix string
+var groupPrefix string
+var file string
+
+type nodesDef struct {
+	numNodes uint
+	kind     string
+	typ      string
+}
 
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
@@ -39,76 +59,173 @@ var generateCmd = &cobra.Command{
 	Aliases: []string{"gen"},
 	Short:   "generate a Clos topology file, based on provided flags",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		generateTopologyConfig(name, mgmtNetName, mgmtIPv4Subnet.String(), mgmtIPv6Subnet.String(), image, kind, nodes...)
-		return nil
+		if name == "" {
+			return errors.New("--name is mandatory")
+		}
+		nodeDefs, licenses, err := parseInput(kind, license, nodes...)
+		if err != nil {
+			return err
+		}
+		b, err := generateTopologyConfig(name, mgmtNetName, mgmtIPv4Subnet.String(), mgmtIPv6Subnet.String(), image, licenses, nodeDefs...)
+		if err != nil {
+			return err
+		}
+		if file == "" {
+			fmt.Println(string(b))
+			return nil
+		}
+		file, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0666)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = file.Write(b)
+		return err
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
-	generateCmd.Flags().StringVarP(&mgmtNetName, "network", "", "", "management network name")
+	generateCmd.Flags().StringVarP(&mgmtNetName, "network", "", "clab", "management network name")
 	generateCmd.Flags().IPNetVarP(&mgmtIPv4Subnet, "ipv4-subnet", "4", net.IPNet{}, "management network IPv4 subnet range")
 	generateCmd.Flags().IPNetVarP(&mgmtIPv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
 	generateCmd.Flags().StringVarP(&image, "image", "", "", "container image name")
 	generateCmd.Flags().StringVarP(&kind, "kind", "", "srl", "container kind")
-	generateCmd.Flags().UintSliceVarP(&nodes, "nodes", "", []uint{}, "comma separated integers represeting the number of nodes per Clos network stage")
-	generateCmd.Flags().StringVarP(&license, "license", "", "", "path to license file")
+	generateCmd.Flags().StringSliceVarP(&nodes, "nodes", "", []string{}, "comma separated nodes definitions in format <num_nodes>:<kind>:<type>, each defining a Clos network stage")
+	generateCmd.Flags().StringSliceVarP(&license, "license", "", []string{}, "path to license file, can be prefix with the node kind. <kind>:/path/to/file")
+	generateCmd.Flags().StringVarP(&nodePrefix, "node-prefix", "", defaultNodePrefix, "prefix used in node names")
+	generateCmd.Flags().StringVarP(&groupPrefix, "group-prefix", "", defaultGroupPrefix, "prefix used in group names")
+	generateCmd.Flags().StringVarP(&file, "file", "", "", "file path to save generated topology")
 }
 
-func generateTopologyConfig(name, network, ipv4range, ipv6range, image, kind string, nodes ...uint) *clab.Config {
+func generateTopologyConfig(name, network, ipv4range, ipv6range, image string, licenses map[string]string, nodes ...nodesDef) ([]byte, error) {
+	numStages := len(nodes)
 	config := &clab.Config{
 		Name: name,
 		Topology: clab.Topology{
+			Kinds: make(map[string]clab.NodeConfig),
 			Nodes: make(map[string]clab.NodeConfig),
 			Defaults: clab.NodeConfig{
-				Kind:    kind,
-				Image:   image,
-				
+				Image: image,
+				//License: license,
 			},
 		},
 	}
 	config.Mgmt.Network = network
-	config.Mgmt.Ipv4Subnet = ipv4range
-	config.Mgmt.Ipv6Subnet = ipv6range
-
-	numStages := len(nodes)
+	if ipv4range != "<nil>" {
+		config.Mgmt.Ipv4Subnet = ipv4range
+	}
+	if ipv6range != "<nil>" {
+		config.Mgmt.Ipv6Subnet = ipv6range
+	}
+	for k, lic := range licenses {
+		config.Topology.Kinds[k] = clab.NodeConfig{License: lic}
+	}
 	for i := 0; i < numStages-1; i++ {
 		interfaceOffset := uint(0)
 		if i > 0 {
-			interfaceOffset = nodes[i-1]
+			interfaceOffset = nodes[i-1].numNodes
 		}
-		for j := uint(0); j < nodes[i]; j++ {
-			node1 := fmt.Sprintf("node%d-%d", i+1, j+1)
+		for j := uint(0); j < nodes[i].numNodes; j++ {
+			node1 := fmt.Sprintf("%s%d-%d", nodePrefix, i+1, j+1)
 			if _, ok := config.Topology.Nodes[node1]; !ok {
 				config.Topology.Nodes[node1] = clab.NodeConfig{
-					Group:   fmt.Sprintf("group-%d", i+1),
-					Type:    "ixr6",
-					License: license,
+					Group: fmt.Sprintf("%s-%d", groupPrefix, i+1),
+					Kind:  nodes[i].kind,
+					Type:  nodes[i].typ,
 				}
 			}
-			for k := uint(0); k < nodes[i+1]; k++ {
-				node2 := fmt.Sprintf("node%d-%d", i+2, k+1)
+			for k := uint(0); k < nodes[i+1].numNodes; k++ {
+				node2 := fmt.Sprintf("%s%d-%d", nodePrefix, i+2, k+1)
 				if _, ok := config.Topology.Nodes[node2]; !ok {
 					config.Topology.Nodes[node2] = clab.NodeConfig{
-						Group:   fmt.Sprintf("group-%d", i+2),
-						Type:    "ixr6",
-						License: license,
+						Group: fmt.Sprintf("%s-%d", groupPrefix, i+2),
+						Kind:  nodes[i+1].kind,
+						Type:  nodes[i+1].typ,
 					}
 				}
 				config.Topology.Links = append(config.Topology.Links, clab.LinkConfig{
 					Endpoints: []string{
-						node1 + ":" + fmt.Sprintf(interfaceFormat[kind], k+1+interfaceOffset),
-						node2 + ":" + fmt.Sprintf(interfaceFormat[kind], j+1),
+						node1 + ":" + fmt.Sprintf(interfaceFormat[nodes[i].kind], k+1+interfaceOffset),
+						node2 + ":" + fmt.Sprintf(interfaceFormat[nodes[i+1].kind], j+1),
 					},
 				})
 			}
 		}
 	}
-
-	out, err := yaml.Marshal(config)
+	return yaml.Marshal(config)
+}
+func parseInput(kind string, license []string, nodes ...string) ([]nodesDef, map[string]string, error) {
+	licenses, err := parseLicenseFlag(kind, license)
 	if err != nil {
-		fmt.Println(err)
+		return nil, nil, err
 	}
-	fmt.Println(string(out))
-	return config
+	result, err := parseNodes(kind, nodes...)
+	return result, licenses, err
+}
+
+func parseLicenseFlag(kind string, license []string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, lic := range license {
+		items := strings.SplitN(lic, ":", 2)
+		switch len(items) {
+		case 1:
+			if _, ok := result[kind]; !ok {
+				result[kind] = items[0]
+			} else {
+				return nil, fmt.Errorf("duplicated license for kind '%s'", kind)
+			}
+		case 2:
+			if _, ok := result[items[0]]; !ok {
+				result[items[0]] = items[1]
+			} else {
+				return nil, fmt.Errorf("duplicated license for kind '%s'", items[1])
+			}
+		}
+	}
+	return result, nil
+}
+
+func parseNodes(kind string, nodes ...string) ([]nodesDef, error) {
+	numStages := len(nodes)
+	if numStages == 0 {
+		return nil, errors.New("no nodes specified using --nodes")
+	}
+	result := make([]nodesDef, numStages)
+	for idx, n := range nodes {
+		def := nodesDef{}
+		items := strings.SplitN(n, ":", 3)
+		if len(items) == 0 {
+			return nil, fmt.Errorf("wrong --nodes format '%s'", n)
+		}
+		i, err := strconv.Atoi(items[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed converting '%s' to an integer: %v", items[0], err)
+		}
+		def.numNodes = uint(i)
+		switch len(items) {
+		case 1:
+			def.kind = kind
+			if kind == "srl" {
+				def.typ = defaultSRLType
+			}
+		case 2:
+			switch items[1] {
+			case "ceos":
+				def.kind = items[1]
+			case "srl":
+				def.kind = items[1]
+				def.typ = defaultSRLType
+			default:
+				def.kind = kind
+				def.typ = items[1]
+			}
+		case 3:
+			def.numNodes = uint(i)
+			def.kind = items[1]
+			def.typ = items[2]
+		}
+		result[idx] = def
+	}
+	return result, nil
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -17,45 +17,98 @@ package cmd
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/spf13/cobra"
 	"github.com/srl-wim/container-lab/clab"
+	"gopkg.in/yaml.v2"
 )
+
+var interfaceFormat = map[string]string{
+	"srl": "e1-%d",
+}
+
+var image string
+var kind string
+var nodes []uint
+var license string
 
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "generate a topology file based on provided flags",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("generate called")
+	Use:     "generate",
+	Aliases: []string{"gen"},
+	Short:   "generate a Clos topology file, based on provided flags",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		generateTopologyConfig(name, mgmtNetName, mgmtIPv4Subnet.String(), mgmtIPv6Subnet.String(), image, kind, nodes...)
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
+	generateCmd.Flags().StringVarP(&mgmtNetName, "network", "", "", "management network name")
+	generateCmd.Flags().IPNetVarP(&mgmtIPv4Subnet, "ipv4-subnet", "4", net.IPNet{}, "management network IPv4 subnet range")
+	generateCmd.Flags().IPNetVarP(&mgmtIPv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
+	generateCmd.Flags().StringVarP(&image, "image", "", "", "container image name")
+	generateCmd.Flags().StringVarP(&kind, "kind", "", "srl", "container kind")
+	generateCmd.Flags().UintSliceVarP(&nodes, "nodes", "", []uint{}, "comma separated integers represeting the number of nodes per Clos network stage")
+	generateCmd.Flags().StringVarP(&license, "license", "", "", "path to license file")
 }
 
-func generateTopologyConfig(name, network, ipv4range, ipv6range, image string, nodes ...uint) *clab.Config {
+func generateTopologyConfig(name, network, ipv4range, ipv6range, image, kind string, nodes ...uint) *clab.Config {
 	config := &clab.Config{
 		Name: name,
+		Topology: clab.Topology{
+			Nodes: make(map[string]clab.NodeConfig),
+			Defaults: clab.NodeConfig{
+				Kind:    kind,
+				Image:   image,
+				
+			},
+		},
 	}
 	config.Mgmt.Network = network
 	config.Mgmt.Ipv4Subnet = ipv4range
 	config.Mgmt.Ipv6Subnet = ipv6range
+
 	numStages := len(nodes)
-	for i := 0; i < numStages-1; i += 2 {
+	for i := 0; i < numStages-1; i++ {
+		interfaceOffset := uint(0)
+		if i > 0 {
+			interfaceOffset = nodes[i-1]
+		}
 		for j := uint(0); j < nodes[i]; j++ {
-			for k := uint(0); k < nodes[i+1]; k++ {
-				config.Topology.Nodes[fmt.Sprintf("node%d-%d", j, k)] = clab.NodeConfig{
-					Group: fmt.Sprintf("group-%d", j),
-					Image: image,
+			node1 := fmt.Sprintf("node%d-%d", i+1, j+1)
+			if _, ok := config.Topology.Nodes[node1]; !ok {
+				config.Topology.Nodes[node1] = clab.NodeConfig{
+					Group:   fmt.Sprintf("group-%d", i+1),
+					Type:    "ixr6",
+					License: license,
 				}
-				config.Topology.Links = append(config.Topology.Links, clab.Link{
-					A: &clab.Endpoint{},
-					B: &clab.Endpoint{},
+			}
+			for k := uint(0); k < nodes[i+1]; k++ {
+				node2 := fmt.Sprintf("node%d-%d", i+2, k+1)
+				if _, ok := config.Topology.Nodes[node2]; !ok {
+					config.Topology.Nodes[node2] = clab.NodeConfig{
+						Group:   fmt.Sprintf("group-%d", i+2),
+						Type:    "ixr6",
+						License: license,
+					}
+				}
+				config.Topology.Links = append(config.Topology.Links, clab.LinkConfig{
+					Endpoints: []string{
+						node1 + ":" + fmt.Sprintf(interfaceFormat[kind], k+1+interfaceOffset),
+						node2 + ":" + fmt.Sprintf(interfaceFormat[kind], j+1),
+					},
 				})
 			}
 		}
 	}
-	return nil
+
+	out, err := yaml.Marshal(config)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(out))
+	return config
 }

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -68,7 +68,7 @@ var generateCmd = &cobra.Command{
 	Short:   "generate a Clos topology file, based on provided flags",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if name == "" {
-			return errors.New("--name is mandatory")
+			return errors.New("provide a lab name with --name flag")
 		}
 		licenses, err := parseFlag(kind, license)
 		if err != nil {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -120,7 +120,7 @@ var generateCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(generateCmd)
-	generateCmd.Flags().StringVarP(&mgmtNetName, "network", "", "clab", "management network name")
+	generateCmd.Flags().StringVarP(&mgmtNetName, "network", "", "", "management network name")
 	generateCmd.Flags().IPNetVarP(&mgmtIPv4Subnet, "ipv4-subnet", "4", net.IPNet{}, "management network IPv4 subnet range")
 	generateCmd.Flags().IPNetVarP(&mgmtIPv6Subnet, "ipv6-subnet", "6", net.IPNet{}, "management network IPv6 subnet range")
 	generateCmd.Flags().StringSliceVarP(&image, "image", "", []string{}, "container image name, can be prefixed with the node kind. <kind>=<image_name>")

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -71,20 +71,25 @@ var generateCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println("licenses:", licenses)
+		log.Debugf("parsed licenses: %+v", licenses)
+
 		images, err := parseFlag(kind, image)
 		if err != nil {
 			return err
 		}
-		fmt.Println("images:", images)
+		log.Debugf("parsed images: %+v", images)
+
 		nodeDefs, err := parseNodesFlag(kind, nodes...)
 		if err != nil {
 			return err
 		}
+		log.Debugf("parsed nodes definitions: %+v", nodeDefs)
+
 		b, err := generateTopologyConfig(name, mgmtNetName, mgmtIPv4Subnet.String(), mgmtIPv6Subnet.String(), images, licenses, nodeDefs...)
 		if err != nil {
 			return err
 		}
+		log.Debugf("generated topo: %s", string(b))
 		if file != "" {
 			err = saveTopoFile(file, b)
 			if err != nil {
@@ -101,7 +106,7 @@ var generateCmd = &cobra.Command{
 				}
 			}
 			topo = file
-			return deployCmd.RunE(deployCmd, []string{})
+			return deployCmd.RunE(deployCmd, nil)
 		}
 		if file == "" {
 			fmt.Println(string(b))

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,61 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/srl-wim/container-lab/clab"
+)
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "generate a topology file based on provided flags",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("generate called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+}
+
+func generateTopologyConfig(name, network, ipv4range, ipv6range, image string, nodes ...uint) *clab.Config {
+	config := &clab.Config{
+		Name: name,
+	}
+	config.Mgmt.Network = network
+	config.Mgmt.Ipv4Subnet = ipv4range
+	config.Mgmt.Ipv6Subnet = ipv6range
+	numStages := len(nodes)
+	for i := 0; i < numStages-1; i += 2 {
+		for j := uint(0); j < nodes[i]; j++ {
+			for k := uint(0); k < nodes[i+1]; k++ {
+				config.Topology.Nodes[fmt.Sprintf("node%d-%d", j, k)] = clab.NodeConfig{
+					Group: fmt.Sprintf("group-%d", j),
+					Image: image,
+				}
+				config.Topology.Links = append(config.Topology.Links, clab.Link{
+					A: &clab.Endpoint{},
+					B: &clab.Endpoint{},
+				})
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type flagInput struct {
+	kind string
+	lics []string
+}
+type flagOutput struct {
+	out map[string]string
+	err error
+}
+
+type nodesInput struct {
+	kind  string
+	nodes []string
+}
+type nodesOutput struct {
+	out []nodesDef
+	err error
+}
+
+var flagTestSet = map[string]struct {
+	in  flagInput
+	out flagOutput
+}{
+	"no_kind": {
+		in: flagInput{
+			kind: "srl",
+			lics: []string{"/path/to/license.key"},
+		},
+		out: flagOutput{
+			out: map[string]string{"srl": "/path/to/license.key"},
+			err: nil,
+		},
+	},
+	"1_item_without_kind": {
+		in: flagInput{
+			kind: "srl",
+			lics: []string{"/path1"},
+		},
+		out: flagOutput{
+			out: map[string]string{"srl": "/path1"},
+			err: nil,
+		},
+	},
+	"1_item_with_kind": {
+		in: flagInput{
+			kind: "srl",
+			lics: []string{"ceos:/path/to/license.key"},
+		},
+		out: flagOutput{
+			out: map[string]string{"ceos": "/path/to/license.key"},
+			err: nil,
+		},
+	},
+	"2_items_with_kind": {
+		in: flagInput{
+			kind: "dummy",
+			lics: []string{"srl:/path1", "ceos:/path2"},
+		},
+		out: flagOutput{
+			out: map[string]string{"srl": "/path1", "ceos": "/path2"},
+			err: nil,
+		},
+	},
+	"2_items_without_kind": {
+		in: flagInput{
+			kind: "srl",
+			lics: []string{"/path1", "/path2"},
+		},
+		out: flagOutput{
+			out: nil,
+			err: errDuplicatedValue,
+		},
+	},
+	"1_item_without_kind_1_item_with_kind": {
+		in: flagInput{
+			kind: "srl",
+			lics: []string{"/path1", "ceos:/path2"},
+		},
+		out: flagOutput{
+			out: map[string]string{"srl": "/path1", "ceos": "/path2"},
+			err: nil,
+		},
+	},
+}
+
+var nodesTestSet = map[string]struct {
+	in  nodesInput
+	out nodesOutput
+}{
+	"no_kind_no_nodes": {
+		in:  nodesInput{kind: "", nodes: nil},
+		out: nodesOutput{out: nil, err: errSyntax},
+	},
+	"no_kind_with_nodes_1": {
+		in: nodesInput{kind: "",
+			nodes: []string{"1", "2", "3"},
+		},
+		out: nodesOutput{out: nil, err: errSyntax},
+	},
+	"no_kind_with_nodes_2": {
+		in: nodesInput{kind: "",
+			nodes: []string{"1:srl", "2", "3"},
+		},
+		out: nodesOutput{out: nil, err: errSyntax},
+	},
+	"no_kind_with_nodes_3": {
+		in: nodesInput{kind: "",
+			nodes: []string{"1:srl", "2:ceos", "3"},
+		},
+		out: nodesOutput{out: nil, err: errSyntax},
+	},
+	"kind_nodes_only_uints": {
+		in: nodesInput{
+			kind:  "srl",
+			nodes: []string{"1", "2", "3"},
+		},
+		out: nodesOutput{
+			out: []nodesDef{
+				{numNodes: 1, kind: "srl", typ: "ixr6"},
+				{numNodes: 2, kind: "srl", typ: "ixr6"},
+				{numNodes: 3, kind: "srl", typ: "ixr6"},
+			},
+			err: nil,
+		},
+	},
+	"kind_nodes_with_kind": {
+		in: nodesInput{
+			kind:  "srl",
+			nodes: []string{"1:srl", "2", "3:ceos"},
+		},
+		out: nodesOutput{
+			out: []nodesDef{
+				{numNodes: 1, kind: "srl", typ: "ixr6"},
+				{numNodes: 2, kind: "srl", typ: "ixr6"},
+				{numNodes: 3, kind: "ceos", typ: ""},
+			},
+			err: nil,
+		},
+	},
+	"kind_nodes_with_kind_and_type": {
+		in: nodesInput{
+			kind:  "srl",
+			nodes: []string{"1:ixrd", "2", "3:ceos"},
+		},
+		out: nodesOutput{
+			out: []nodesDef{
+				{numNodes: 1, kind: "srl", typ: "ixrd"},
+				{numNodes: 2, kind: "srl", typ: "ixr6"},
+				{numNodes: 3, kind: "ceos", typ: ""},
+			},
+			err: nil,
+		},
+	},
+}
+
+func TestParseFlag(t *testing.T) {
+	for name, set := range flagTestSet {
+		t.Logf("test '%s' running", name)
+		result, err := parseFlag(set.in.kind, set.in.lics)
+		if !cmp.Equal(result, set.out.out) {
+			t.Errorf("failed at '%s', expected %v, got %+v", name, set.out.out, result)
+		}
+		if err != set.out.err {
+			t.Errorf("failed at '%s', expected error %+v, got %+v", name, set.out.err, err)
+		}
+		t.Logf("test '%s' OK", name)
+	}
+}
+
+func TestParseNodes(t *testing.T) {
+	for name, set := range nodesTestSet {
+		t.Logf("test '%s' running", name)
+		result, err := parseNodesFlag(set.in.kind, set.in.nodes...)
+		if !cmp.Equal(result, set.out.out, cmp.AllowUnexported(nodesDef{})) {
+			t.Errorf("failed at '%s', expected %+v, got %+v", name, set.out.out, result)
+		}
+		if err != set.out.err {
+			t.Errorf("failed at '%s', expected error %+v, got %+v", name, set.out.err, err)
+		}
+		t.Logf("test '%s' OK", name)
+	}
+}

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -133,11 +133,11 @@ var nodesTestSet = map[string]struct {
 	"kind_nodes_with_kind": {
 		in: nodesInput{
 			kind:  "srl",
-			nodes: []string{"1:srl", "2", "3:ceos"},
+			nodes: []string{"1:linux", "2", "3:ceos"},
 		},
 		out: nodesOutput{
 			out: []nodesDef{
-				{numNodes: 1, kind: "srl", typ: "ixr6"},
+				{numNodes: 1, kind: "linux", typ: ""},
 				{numNodes: 2, kind: "srl", typ: "ixr6"},
 				{numNodes: 3, kind: "ceos", typ: ""},
 			},

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -51,7 +51,7 @@ var flagTestSet = map[string]struct {
 	"1_item_with_kind": {
 		in: flagInput{
 			kind: "srl",
-			lics: []string{"ceos:/path/to/license.key"},
+			lics: []string{"ceos=/path/to/license.key"},
 		},
 		out: flagOutput{
 			out: map[string]string{"ceos": "/path/to/license.key"},
@@ -61,7 +61,7 @@ var flagTestSet = map[string]struct {
 	"2_items_with_kind": {
 		in: flagInput{
 			kind: "dummy",
-			lics: []string{"srl:/path1", "ceos:/path2"},
+			lics: []string{"srl=/path1", "ceos=/path2"},
 		},
 		out: flagOutput{
 			out: map[string]string{"srl": "/path1", "ceos": "/path2"},
@@ -81,7 +81,7 @@ var flagTestSet = map[string]struct {
 	"1_item_without_kind_1_item_with_kind": {
 		in: flagInput{
 			kind: "srl",
-			lics: []string{"/path1", "ceos:/path2"},
+			lics: []string{"/path1", "ceos=/path2"},
 		},
 		out: flagOutput{
 			out: map[string]string{"srl": "/path1", "ceos": "/path2"},

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -158,6 +158,18 @@ var nodesTestSet = map[string]struct {
 			err: nil,
 		},
 	},
+	"single_stage": {
+		in: nodesInput{
+			kind:  "srl",
+			nodes: []string{"2"},
+		},
+		out: nodesOutput{
+			out: []nodesDef{
+				{numNodes: 2, kind: "srl", typ: "ixr6"},
+			},
+			err: nil,
+		},
+	},
 }
 
 func TestParseFlag(t *testing.T) {

--- a/cmd/generate_test.go
+++ b/cmd/generate_test.go
@@ -162,28 +162,28 @@ var nodesTestSet = map[string]struct {
 
 func TestParseFlag(t *testing.T) {
 	for name, set := range flagTestSet {
-		t.Logf("test '%s' running", name)
-		result, err := parseFlag(set.in.kind, set.in.lics)
-		if !cmp.Equal(result, set.out.out) {
-			t.Errorf("failed at '%s', expected %v, got %+v", name, set.out.out, result)
-		}
-		if err != set.out.err {
-			t.Errorf("failed at '%s', expected error %+v, got %+v", name, set.out.err, err)
-		}
-		t.Logf("test '%s' OK", name)
+		t.Run(name, func(t *testing.T) {
+			result, err := parseFlag(set.in.kind, set.in.lics)
+			if !cmp.Equal(result, set.out.out) {
+				t.Errorf("failed at '%s', expected %v, got %+v", name, set.out.out, result)
+			}
+			if err != set.out.err {
+				t.Errorf("failed at '%s', expected error %+v, got %+v", name, set.out.err, err)
+			}
+		})
 	}
 }
 
 func TestParseNodes(t *testing.T) {
 	for name, set := range nodesTestSet {
-		t.Logf("test '%s' running", name)
-		result, err := parseNodesFlag(set.in.kind, set.in.nodes...)
-		if !cmp.Equal(result, set.out.out, cmp.AllowUnexported(nodesDef{})) {
-			t.Errorf("failed at '%s', expected %+v, got %+v", name, set.out.out, result)
-		}
-		if err != set.out.err {
-			t.Errorf("failed at '%s', expected error %+v, got %+v", name, set.out.err, err)
-		}
-		t.Logf("test '%s' OK", name)
+		t.Run(name, func(t *testing.T) {
+			result, err := parseNodesFlag(set.in.kind, set.in.nodes...)
+			if !cmp.Equal(result, set.out.out, cmp.AllowUnexported(nodesDef{})) {
+				t.Errorf("failed at '%s', expected %+v, got %+v", name, set.out.out, result)
+			}
+			if err != set.out.err {
+				t.Errorf("failed at '%s', expected error %+v, got %+v", name, set.out.err, err)
+			}
+		})
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,9 +29,15 @@ var rootCmd = &cobra.Command{
 	Use:   "containerlab",
 	Short: "deploy container based lab environments with a user-defined interconnections",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		id := os.Geteuid()
+		if id != 0 {
+			fmt.Println("containerlab requires sudo privileges to run!")
+			os.Exit(1)
+		}
 		if debug {
 			log.SetLevel(log.DebugLevel)
 		}
+
 	},
 }
 
@@ -44,11 +50,6 @@ func Execute() {
 }
 
 func init() {
-	id := os.Geteuid()
-	if id != 0 {
-		fmt.Println("containerlab requires sudo privileges to run!")
-		os.Exit(1)
-	}
 
 	rootCmd.SilenceUsage = true
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "enable debug mode")

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vishvananda/netlink v1.1.0
-	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae
+	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/google/go-cmp v0.2.0
 	github.com/google/uuid v1.1.2
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/certificate-transparency-go v1.0.21 h1:Yf1aXowfZ2nuboBsg7iYGLmwsOARdV86pfH3g95wXmE=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
This PR adds `generate` command that is used to generate a topology file based on supplied flags,
The topology file is printed to stdout or saved to a custom location if specified with `--file` 

flags:
`--kind`: `srl` or `ceos` for the moment, specifies the kind of node to be deployed

`--network`: the docker network name to be used a management network

`--ipv4-subnet` : management network IPv4 subnet range

`--ipv6-subnet` : management network IPv6 subnet range

`--image` : container image name, can be prefixed with the node kind. <kind>:<image_name>

 if the kind value is missing from `--image` is is taken from `--kind` flag

`--license`: path to license file, can be prefix with the node kind. <kind>:/path/to/file

if the kind value is missing from `--license` is is taken from `--kind` flag

`--nodes` : comma separated nodes definitions in format <num_nodes>:<kind>:<type>, each defining a Clos network stage

if the kind value is missing from `--nodes` is is taken from `--kind` flag

for e.g: `--nodes 3:srl,2:srl,1:ceos` results in a 3 states fabric with 3 srls, 2 srls, then 1 ceos node


`--node-prefix` : prefix used in node names

`--group-prefix` : prefix used in group names


EDIT: added `--deploy` flag which will save the generated topology to `--file` value or `$name.yaml` if `--file` is not set.
it then calls deployCmd.RunE with `reconfigure=true` and `topo=file`