### PR TITLE
fix inspect cmd --format flag has a wrong definition #145

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -76,7 +76,7 @@ func init() {
 	rootCmd.AddCommand(inspectCmd)
 
 	inspectCmd.Flags().BoolVarP(&details, "details", "", false, "print all details of lab containers")
-	inspectCmd.Flags().StringVarP(&format, "format", "f", "", "lab name")
+	inspectCmd.Flags().StringVarP(&format, "format", "f", "table", "output format. One of [table, json]")
 }
 
 func toTableData(det []containerDetails) [][]string {


### PR DESCRIPTION
closes #145 