### PR TITLE
List all containers

### DIFF
--- a/clab/docker.go
+++ b/clab/docker.go
@@ -267,6 +267,7 @@ func (c *cLab) ListContainers(ctx context.Context, labels []string) ([]types.Con
 		filter.Add("label", l)
 	}
 	return c.DockerClient.ContainerList(ctx, types.ContainerListOptions{
+		All:     true,
 		Filters: filter,
 	})
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -54,6 +54,9 @@ var execCmd = &cobra.Command{
 			cmds = append(cmds, strings.Split(a, " ")...)
 		}
 		for _, cont := range containers {
+			if cont.State != "running" {
+				continue
+			}
 			stdout, stderr, err := c.Exec(ctx, cont.ID, cmds)
 			if err != nil {
 				log.Errorf("%s: failed to execute cmd: %v", cont.Names, err)

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -44,6 +44,9 @@ Refer to the https://containerlab.srlinux.dev/cmd/save/ documentation to see the
 		}
 		var saveCmd []string
 		for _, cont := range containers {
+			if cont.State != "running" {
+				continue
+			}
 			log.Debugf("container: %+v", cont)
 			if k, ok := cont.Labels["kind"]; ok {
 				switch k {


### PR DESCRIPTION
This PR allows to list all containers from clab (including non-running ones).
This will help destroying lab with exited/failed containers