### PR TITLE
the way to update docs off-cycle

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: docs
 on:
   push:
     branches:
-      - "docs-*"
+      - "__docs"
     tags:
       - "v*"
 


### PR DESCRIPTION
The problem we have is how to update the docs between the releases when we need to add missing docs or fix something

the proposal is to have a long-lived branch named [`__docs`](https://github.com/srl-wim/container-lab/tree/__docs) that will only receive pull requests/pushes with docs additions. On push event to this branch we will rebuild the docs.

Once in a while we sync the merge `__docs` to `master` for master to have the additions made to __docs.

the workflow:

1. on a tagged release we merge the master to __docs
2. then, between the releases, if changes are needed to be rendered on the docs portal we create a PR that targets __docs branch
3. when docs changed is approved and such PR is merged, the changes will be pushed to __docs branch. That will trigger a documentation build and publish process
4. when we develop new features the PR will target master branch, therefore the docs for the features which are not yet released will not appear on the doc site.
5. if the changes are made to the structure of the doc portal in the __docs branch, and these changes are needed in the main branch, we merge __docs to master, not to the PR branch.