### PR TITLE
added clab symlink to package installer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,3 +37,5 @@ nfpms:
     files:
       ./lab-examples/**/*: /etc/containerlab/lab-examples
       ./templates/**/*: /etc/containerlab/templates
+    symlinks:
+      /usr/bin/clab: /usr/bin/containerlab

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ nfpms:
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     package_name: containerlab
     maintainer: Wim Henderickx <wim.henderickx@nokia.com>, Karim Radhouani <medkarimrdi@gmail.com>, Roman Dodin <dodin.roman@gmail.com>
-    homepage: containerlab.srlinux.dev
+    homepage: https://containerlab.srlinux.dev
     description: |
       containerlab written in go
     vendor: Nokia

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,7 @@ nfpms:
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     package_name: containerlab
     maintainer: Wim Henderickx <wim.henderickx@nokia.com>, Karim Radhouani <medkarimrdi@gmail.com>, Roman Dodin <dodin.roman@gmail.com>
+    homepage: containerlab.srlinux.dev
     description: |
       containerlab written in go
     vendor: Nokia

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,6 +29,8 @@ sudo curl -sL https://get-clab.srlinux.dev | sudo bash -s -- -v 0.6.0
     yum install https://github.com/srl-wim/container-lab/releases/download/v0.7.0/containerlab_0.7.0_linux_386.rpm
     ```
 
+The package installer will put the `containerlab` binary in the `/usr/bin` directory as well as create the `/usr/bin/clab -> /usr/bin/containerlab` symlink. The symlink allows the users to save on typing when they use containerlab: `clab <command>`.
+
 ### Upgrade
 To upgrade `containerlab` to the latest available version issue the following command:
 


### PR DESCRIPTION
making it possible to use `clab <command>` iso `containerlab <command>`