### PR TITLE
deploy with reconfigure to cause lab destroy

### DIFF
--- a/clab/cert.go
+++ b/clab/cert.go
@@ -37,7 +37,7 @@ type CaRootInput struct {
 }
 
 // GenerateRootCa function
-func (c *cLab) GenerateRootCa(csrRootJsonTpl *template.Template, input CaRootInput) (*certificates, error) {
+func (c *CLab) GenerateRootCa(csrRootJsonTpl *template.Template, input CaRootInput) (*certificates, error) {
 	log.Info("Creating root CA")
 	//create root CA diretcory
 	CreateDirectory(c.Dir.LabCA, 0755)
@@ -72,7 +72,7 @@ func (c *cLab) GenerateRootCa(csrRootJsonTpl *template.Template, input CaRootInp
 	return certs, nil
 }
 
-func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Template, node *Node) (*certificates, error) {
+func (c *CLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Template, node *Node) (*certificates, error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 	input := CertInput{
@@ -141,7 +141,7 @@ func (c *cLab) GenerateCert(ca string, caKey string, csrJSONTpl *template.Templa
 	return certs, nil
 }
 
-func (c *cLab) writeCertFiles(certs *certificates, filesPrefix string) {
+func (c *CLab) writeCertFiles(certs *certificates, filesPrefix string) {
 	createFile(filesPrefix+".pem", string(certs.Cert))
 	createFile(filesPrefix+"-key.pem", string(certs.Key))
 	createFile(filesPrefix+".csr", string(certs.Csr))

--- a/clab/clab.go
+++ b/clab/clab.go
@@ -13,7 +13,7 @@ import (
 
 // var debug bool
 
-type cLab struct {
+type CLab struct {
 	Config       *Config
 	TopoFile     *TopoFile
 	m            *sync.RWMutex
@@ -34,22 +34,22 @@ type cLabDirectory struct {
 	LabGraph  string
 }
 
-type ClabOption func(c *cLab)
+type ClabOption func(c *CLab)
 
 func WithDebug(d bool) ClabOption {
-	return func(c *cLab) {
+	return func(c *CLab) {
 		c.debug = d
 	}
 }
 
 func WithTimeout(dur time.Duration) ClabOption {
-	return func(c *cLab) {
+	return func(c *CLab) {
 		c.timeout = dur
 	}
 }
 
 func WithEnvDockerClient() ClabOption {
-	return func(c *cLab) {
+	return func(c *CLab) {
 		var err error
 		c.DockerClient, err = docker.NewEnvClient()
 		if err != nil {
@@ -59,7 +59,7 @@ func WithEnvDockerClient() ClabOption {
 }
 
 func WithTopoFile(file string) ClabOption {
-	return func(c *cLab) {
+	return func(c *CLab) {
 		if file == "" {
 			return
 		}
@@ -70,14 +70,14 @@ func WithTopoFile(file string) ClabOption {
 }
 
 func WithGracefulShutdown(gracefulShutdown bool) ClabOption {
-	return func(c *cLab) {
+	return func(c *CLab) {
 		c.gracefulShutdown = gracefulShutdown
 	}
 }
 
 // NewContainerLab function defines a new container lab
-func NewContainerLab(opts ...ClabOption) *cLab {
-	c := &cLab{
+func NewContainerLab(opts ...ClabOption) *CLab {
+	c := &CLab{
 		Config:   new(Config),
 		TopoFile: new(TopoFile),
 		m:        new(sync.RWMutex),
@@ -90,7 +90,7 @@ func NewContainerLab(opts ...ClabOption) *cLab {
 	return c
 }
 
-func (c *cLab) CreateNode(ctx context.Context, node *Node, certs *certificates) error {
+func (c *CLab) CreateNode(ctx context.Context, node *Node, certs *certificates) error {
 	c.m.Lock()
 	node.TLSCert = string(certs.Cert)
 	node.TLSKey = string(certs.Key)
@@ -103,7 +103,7 @@ func (c *cLab) CreateNode(ctx context.Context, node *Node, certs *certificates) 
 }
 
 // ExecPostDeployTasks executes tasks that some nodes might require to boot properly after start
-func (c *cLab) ExecPostDeployTasks(ctx context.Context, node *Node) error {
+func (c *CLab) ExecPostDeployTasks(ctx context.Context, node *Node) error {
 	switch node.Kind {
 	case "ceos":
 		log.Debugf("Running postdeploy actions for Arista cEOS '%s' node", node.ShortName)

--- a/clab/config.go
+++ b/clab/config.go
@@ -138,7 +138,7 @@ type Endpoint struct {
 }
 
 // ParseIPInfo parses IP information
-func (c *cLab) parseIPInfo() error {
+func (c *CLab) parseIPInfo() error {
 	if c.Config.Mgmt.Network == "" {
 		c.Config.Mgmt.Network = dockerNetName
 	}
@@ -158,7 +158,7 @@ func (c *cLab) parseIPInfo() error {
 }
 
 // ParseTopology parses the lab topology
-func (c *cLab) ParseTopology() error {
+func (c *CLab) ParseTopology() error {
 	log.Info("Parsing topology information ...")
 	log.Debugf("Lab name: %s", c.Config.Name)
 	// initialize DockerInfo
@@ -197,14 +197,14 @@ func (c *cLab) ParseTopology() error {
 	return nil
 }
 
-func (c *cLab) kindInitialization(nodeCfg *NodeConfig) string {
+func (c *CLab) kindInitialization(nodeCfg *NodeConfig) string {
 	if nodeCfg.Kind != "" {
 		return nodeCfg.Kind
 	}
 	return c.Config.Topology.Defaults.Kind
 }
 
-func (c *cLab) bindsInit(nodeCfg *NodeConfig) []string {
+func (c *CLab) bindsInit(nodeCfg *NodeConfig) []string {
 	switch {
 	case len(nodeCfg.Binds) != 0:
 		return nodeCfg.Binds
@@ -217,7 +217,7 @@ func (c *cLab) bindsInit(nodeCfg *NodeConfig) []string {
 }
 
 // portsInit produces the nat.PortMap out of the slice of string representation of port bindings
-func (c *cLab) portsInit(nodeCfg *NodeConfig) (nat.PortSet, nat.PortMap, error) {
+func (c *CLab) portsInit(nodeCfg *NodeConfig) (nat.PortSet, nat.PortMap, error) {
 	if len(nodeCfg.Ports) != 0 {
 		ps, pb, err := nat.ParsePortSpecs(nodeCfg.Ports)
 		if err != nil {
@@ -228,7 +228,7 @@ func (c *cLab) portsInit(nodeCfg *NodeConfig) (nat.PortSet, nat.PortMap, error) 
 	return nil, nil, nil
 }
 
-func (c *cLab) groupInitialization(nodeCfg *NodeConfig, kind string) string {
+func (c *CLab) groupInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Group != "" {
 		return nodeCfg.Group
 	} else if c.Config.Topology.Kinds[kind].Group != "" {
@@ -238,7 +238,7 @@ func (c *cLab) groupInitialization(nodeCfg *NodeConfig, kind string) string {
 }
 
 // initialize SRL HW type
-func (c *cLab) typeInit(nodeCfg *NodeConfig, kind string) string {
+func (c *CLab) typeInit(nodeCfg *NodeConfig, kind string) string {
 	switch {
 	case nodeCfg.Type != "":
 		return nodeCfg.Type
@@ -255,7 +255,7 @@ func (c *cLab) typeInit(nodeCfg *NodeConfig, kind string) string {
 	return ""
 }
 
-func (c *cLab) configInitialization(nodeCfg *NodeConfig, kind string) string {
+func (c *CLab) configInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Config != "" {
 		return nodeCfg.Config
 	}
@@ -270,7 +270,7 @@ func (c *cLab) configInitialization(nodeCfg *NodeConfig, kind string) string {
 	return defaultConfigTemplates[kind]
 }
 
-func (c *cLab) imageInitialization(nodeCfg *NodeConfig, kind string) string {
+func (c *CLab) imageInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Image != "" {
 		return nodeCfg.Image
 	}
@@ -280,7 +280,7 @@ func (c *cLab) imageInitialization(nodeCfg *NodeConfig, kind string) string {
 	return c.Config.Topology.Defaults.Image
 }
 
-func (c *cLab) licenseInit(nodeCfg *NodeConfig, node *Node) (string, error) {
+func (c *CLab) licenseInit(nodeCfg *NodeConfig, node *Node) (string, error) {
 	switch {
 	case nodeCfg.License != "":
 		return nodeCfg.License, nil
@@ -293,7 +293,7 @@ func (c *cLab) licenseInit(nodeCfg *NodeConfig, node *Node) (string, error) {
 	}
 }
 
-func (c *cLab) cmdInit(nodeCfg *NodeConfig, kind string) string {
+func (c *CLab) cmdInit(nodeCfg *NodeConfig, kind string) string {
 	switch {
 	case nodeCfg.Cmd != "":
 		return nodeCfg.Cmd
@@ -307,7 +307,7 @@ func (c *cLab) cmdInit(nodeCfg *NodeConfig, kind string) string {
 	return ""
 }
 
-func (c *cLab) positionInitialization(nodeCfg *NodeConfig, kind string) string {
+func (c *CLab) positionInitialization(nodeCfg *NodeConfig, kind string) string {
 	if nodeCfg.Position != "" {
 		return nodeCfg.Position
 	} else if c.Config.Topology.Kinds[kind].Position != "" {
@@ -317,7 +317,7 @@ func (c *cLab) positionInitialization(nodeCfg *NodeConfig, kind string) string {
 }
 
 // NewNode initializes a new node object
-func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
+func (c *CLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 	// initialize a new node
 	node := new(Node)
 	node.ShortName = nodeName
@@ -467,7 +467,7 @@ func (c *cLab) NewNode(nodeName string, nodeCfg NodeConfig, idx int) error {
 }
 
 // NewLink initializes a new link object
-func (c *cLab) NewLink(l LinkConfig) *Link {
+func (c *CLab) NewLink(l LinkConfig) *Link {
 	// initialize a new link
 	link := new(Link)
 	link.Labels = l.Labels
@@ -489,7 +489,7 @@ func (c *cLab) NewLink(l LinkConfig) *Link {
 }
 
 // NewEndpoint initializes a new endpoint object
-func (c *cLab) NewEndpoint(e string) *Endpoint {
+func (c *CLab) NewEndpoint(e string) *Endpoint {
 	// initialize a new endpoint
 	endpoint := new(Endpoint)
 
@@ -524,7 +524,7 @@ func (c *cLab) NewEndpoint(e string) *Endpoint {
 }
 
 // VerifyBridgeExists verifies if every node of kind=bridge exists on the lab host
-func (c *cLab) VerifyBridgesExist() error {
+func (c *CLab) VerifyBridgesExist() error {
 	for name, node := range c.Nodes {
 		if node.Kind == "bridge" {
 			if _, err := netlink.LinkByName(name); err != nil {

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -22,7 +22,7 @@ import (
 const sysctlBase = "/proc/sys"
 
 // CreateBridge creates a docker bridge
-func (c *cLab) CreateBridge(ctx context.Context) (err error) {
+func (c *CLab) CreateBridge(ctx context.Context) (err error) {
 	log.Infof("Creating docker network: Name='%s', IPv4Subnet='%s', IPv6Subnet='%s'", c.Config.Mgmt.Network, c.Config.Mgmt.IPv4Subnet, c.Config.Mgmt.IPv6Subnet)
 
 	enableIPv6 := false
@@ -117,7 +117,7 @@ func (c *cLab) CreateBridge(ctx context.Context) (err error) {
 }
 
 // DeleteBridge deletes a docker bridge
-func (c *cLab) DeleteBridge(ctx context.Context) (err error) {
+func (c *CLab) DeleteBridge(ctx context.Context) (err error) {
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	nres, err := c.DockerClient.NetworkInspect(ctx, c.Config.Mgmt.Network)
@@ -142,7 +142,7 @@ func (c *cLab) DeleteBridge(ctx context.Context) (err error) {
 }
 
 // CreateContainer creates a docker container
-func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
+func (c *CLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	log.Infof("Creating container: %s", node.ShortName)
 
 	err = c.PullImageIfRequired(ctx, node.Image)
@@ -215,7 +215,7 @@ func (c *cLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	return linkContainerNS(node.NSPath, node.LongName)
 }
 
-func (c *cLab) PullImageIfRequired(ctx context.Context, imageName string) error {
+func (c *CLab) PullImageIfRequired(ctx context.Context, imageName string) error {
 	filter := filters.NewArgs()
 	filter.Add("reference", imageName)
 
@@ -265,7 +265,7 @@ func (c *cLab) PullImageIfRequired(ctx context.Context, imageName string) error 
 }
 
 // StartContainer starts a docker container
-func (c *cLab) StartContainer(ctx context.Context, id string) error {
+func (c *CLab) StartContainer(ctx context.Context, id string) error {
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	return c.DockerClient.ContainerStart(nctx,
@@ -278,7 +278,7 @@ func (c *cLab) StartContainer(ctx context.Context, id string) error {
 }
 
 // ListContainers lists all containers with labels []string
-func (c *cLab) ListContainers(ctx context.Context, labels []string) ([]types.Container, error) {
+func (c *CLab) ListContainers(ctx context.Context, labels []string) ([]types.Container, error) {
 	ctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	filter := filters.NewArgs()
@@ -292,7 +292,7 @@ func (c *cLab) ListContainers(ctx context.Context, labels []string) ([]types.Con
 }
 
 // Exec executes cmd on container identified with id and returns stdout, stderr bytes and an error
-func (c *cLab) Exec(ctx context.Context, id string, cmd []string) ([]byte, []byte, error) {
+func (c *CLab) Exec(ctx context.Context, id string, cmd []string) ([]byte, []byte, error) {
 	cont, err := c.DockerClient.ContainerInspect(ctx, id)
 	if err != nil {
 		return nil, nil, err
@@ -341,7 +341,7 @@ func (c *cLab) Exec(ctx context.Context, id string, cmd []string) ([]byte, []byt
 }
 
 // DeleteContainer tries to stop a container then remove it
-func (c *cLab) DeleteContainer(ctx context.Context, name string) error {
+func (c *CLab) DeleteContainer(ctx context.Context, name string) error {
 	var err error
 	force := !c.gracefulShutdown
 	if c.gracefulShutdown {

--- a/clab/file.go
+++ b/clab/file.go
@@ -23,7 +23,7 @@ type TopoFile struct {
 
 // GetTopology parses the topology file into c.Conf structure
 // as well as populates the TopoFile structure with the topology file related information
-func (c *cLab) GetTopology(topo string) error {
+func (c *CLab) GetTopology(topo string) error {
 	log.Infof("Getting topology information from %s file...", topo)
 
 	yamlFile, err := ioutil.ReadFile(topo)
@@ -133,7 +133,7 @@ func CreateDirectory(path string, perm os.FileMode) {
 }
 
 // CreateNodeDirStructure create the directory structure and files for the lab nodes
-func (c *cLab) CreateNodeDirStructure(node *Node) (err error) {
+func (c *CLab) CreateNodeDirStructure(node *Node) (err error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 

--- a/clab/graph.go
+++ b/clab/graph.go
@@ -12,7 +12,7 @@ import (
 var g *gographviz.Graph
 
 // GenerateGraph generates a graph of the lab topology
-func (c *cLab) GenerateGraph(topo string) error {
+func (c *CLab) GenerateGraph(topo string) error {
 	log.Info("Generating lab graph...")
 	g = gographviz.NewGraph()
 	if err := g.SetName(c.TopoFile.name); err != nil {

--- a/clab/netlink.go
+++ b/clab/netlink.go
@@ -20,7 +20,7 @@ type vEthEndpoint struct {
 }
 
 // CreateVirtualWiring provides the virtual topology between the containers
-func (c *cLab) CreateVirtualWiring(l *Link) (err error) {
+func (c *CLab) CreateVirtualWiring(l *Link) (err error) {
 	log.Infof("Creating virtual wire: %s:%s <--> %s:%s", l.A.Node.ShortName, l.A.EndpointName, l.B.Node.ShortName, l.B.EndpointName)
 
 	// connect containers (or container and a bridge) using veth pair
@@ -165,7 +165,7 @@ func (veth *vEthEndpoint) toBridge() error {
 }
 
 // DeleteNetnsSymlinks deletes the symlink file created for each container netns
-func (c *cLab) DeleteNetnsSymlinks() (err error) {
+func (c *CLab) DeleteNetnsSymlinks() (err error) {
 	for _, node := range c.Nodes {
 		if node.Kind != "bridge" {
 			log.Debugf("Deleting %s network namespace", node.LongName)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -66,7 +66,6 @@ var deployCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			log.Info("Destroying lab...")
 			destroyLab(ctx, c)
 
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -51,6 +51,9 @@ var deployCmd = &cobra.Command{
 		}
 		c := clab.NewContainerLab(opts...)
 
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
 		setFlags(c.Config)
 		log.Debugf("lab Conf: %+v", c.Config)
 		// Parse topology information
@@ -58,17 +61,18 @@ var deployCmd = &cobra.Command{
 			return err
 		}
 		if reconfigure {
+			log.Infof("Removing %s directory...", c.Dir.Lab)
 			err = os.RemoveAll(c.Dir.Lab)
 			if err != nil {
 				return err
 			}
+			log.Info("Destroying lab...")
+			destroyLab(ctx, c)
+
 		}
 		if err = c.VerifyBridgesExist(); err != nil {
 			return err
 		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
 
 		// create lab directory
 		log.Info("Creating lab directory: ", c.Dir.Lab)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -141,7 +141,11 @@ func destroyLab(ctx context.Context, c *clab.CLab) (err error) {
 	// delete lab management network
 	log.Infof("Deleting docker network '%s'...", c.Config.Mgmt.Network)
 	if err = c.DeleteBridge(ctx); err != nil {
-		log.Error(err)
+		// do not log error message if deletion error simply says that such network doesn't exist
+		if err.Error() != fmt.Sprintf("Error: No such network: %s", c.Config.Mgmt.Network) {
+			log.Error(err)
+		}
+
 	}
 	// delete container network namespaces symlinks
 	c.DeleteNetnsSymlinks()

--- a/docs/cmd/deploy.md
+++ b/docs/cmd/deploy.md
@@ -22,7 +22,7 @@ With the global `--name | -n` flag a user sets a lab name. This value will overr
 
 #### reconfigure
 
-The local `--reconfigure` flag instructs containerlab to remove the lab directory and all its content (if such directory exists) and start the deploy process after that. That will result in a clean deployment where every configuration artefact will be generated (TLS, node config) from scratch.
+The local `--reconfigure` flag instructs containerlab to first **destroy** the lab and all its directories and then start the deployment process. That will result in a clean (re)deployment where every configuration artefact will be generated (TLS, node config) from scratch.
 
 Without this flag present, containerlab will reuse the available configuration artifacts found in the lab directory.
 


### PR DESCRIPTION
@karimra  I took a very simplistic approach to enable #210 

That required to make `clab.CLab` exported, hence lots of files touched. I know that you wanted to rework the commands, so feel free to propose your vision and I can rebase this PR on the new way of commands execution


close #210