### PR TITLE
pull images before deployment

### DIFF
--- a/clab/config.go
+++ b/clab/config.go
@@ -1,6 +1,7 @@
 package clab
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -717,6 +718,24 @@ func (c *CLab) verifyLinks() error {
 	}
 	if len(dups) != 0 {
 		return fmt.Errorf("endpoints %q appeared more than once in the links section of the topology file", dups)
+	}
+	return nil
+}
+
+// VerifyImages will check if image referred in the node config
+// either pullable or present or is available in the local registry
+// if it is not available it will emit an error
+func (c *CLab) VerifyImages(ctx context.Context) error {
+	images := map[string]struct{}{}
+	for _, node := range c.Nodes {
+		images[node.Image] = struct{}{}
+	}
+
+	for image := range images {
+		err := c.PullImageIfRequired(ctx, image)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/clab/docker.go
+++ b/clab/docker.go
@@ -145,11 +145,6 @@ func (c *CLab) DeleteBridge(ctx context.Context) (err error) {
 func (c *CLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	log.Infof("Creating container: %s", node.ShortName)
 
-	err = c.PullImageIfRequired(ctx, node.Image)
-	if err != nil {
-		return err
-	}
-
 	nctx, cancel := context.WithTimeout(ctx, c.timeout)
 	defer cancel()
 	labels := map[string]string{

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -64,6 +64,11 @@ var deployCmd = &cobra.Command{
 		if err = c.ParseTopology(); err != nil {
 			return err
 		}
+
+		if err = c.VerifyImages(ctx); err != nil {
+			return err
+		}
+
 		if reconfigure {
 			if err != nil {
 				return err


### PR DESCRIPTION
check if all images referred in a topo file can be either pulled or found locally before creating any nodes 