### PR TITLE
added host interfaces connectivity

### DIFF
--- a/clab/clab.go
+++ b/clab/clab.go
@@ -220,10 +220,10 @@ func (c *CLab) CreateLinks(ctx context.Context, workers uint, linksChan chan *Li
 				select {
 				case link := <-linksChan:
 					if link == nil {
-						log.Debugf("Worker %d terminating...", i)
+						log.Debugf("Link worker %d terminating...", i)
 						return
 					}
-					log.Debugf("Worker %d received link: %+v", i, link)
+					log.Debugf("Link worker %d received link: %+v", i, link)
 					if err := c.CreateVirtualWiring(link); err != nil {
 						log.Error(err)
 					}

--- a/clab/config.go
+++ b/clab/config.go
@@ -762,7 +762,7 @@ func (c *CLab) NewEndpoint(e string) *Endpoint {
 
 	// stop the deployment if the matching node element was not found
 	// "host" node name is an exception, it may exist without a matching node
-	if endpoint.Node == nil && nName != "host" {
+	if endpoint.Node == nil {
 		log.Fatalf("Not all nodes are specified in the 'topology.nodes' section or the names don't match in the 'links.endpoints' section: %s", nName)
 	}
 

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -193,3 +193,31 @@ Management network is used to provide management access to the NOS containers, i
 The above diagram shows how links are created in the topology definition file. In this example, the datapath consists of the two virtual point-to-point wires between SR Linux and cEOS containers. These links are created on-demand by containerlab itself.
 
 The p2p links are provided by the `veth` device pairs where each end of the `veth` pair is attached to a respective container.
+
+### host links
+It is also possible to interconnect container' data inteface not with other container or add it to a [bridge](kinds/bridge.md), but to attach it to a host's root namespace. This is, for example, needed to create a L2 connectivity between containerlab nodes running on different VMs (aka multi-node labs).
+
+This "host-connectivity" is achieved by using a reserved node name - `host` - referenced in the endpoints section. Consider the following example where an SR Linux container has its only data interface connected to a hosts root namespace via veth interface:
+
+```yaml
+name: host
+
+topology:
+  nodes:
+    srl:
+      kind: srl
+      image: srlinux:20.6.3-145
+      license: license.key
+      config: test-srl-config.json
+  links:
+    - endpoints: ["srl:e1-1", "host:srl_e1-1"]
+```
+
+With this topology definition, we will have a veth interface with its one end in the container' namespace and its other end in the host namespace. The host will have the interface named `srl_e1-1` once the lab deployed:
+
+```bash
+ip link
+# SNIP
+433: srl_e1-1@if434: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
+    link/ether b2:80:e9:60:c7:9d brd ff:ff:ff:ff:ff:ff link-netns clab-srl01-srl
+```


### PR DESCRIPTION
added possibility to create p2p links from containers to host's namespace;

the special node name in the endpoints `host` will tell clab to put the veth in the host namespace under the specified name

example:

```yaml
name: host

topology:
  nodes:
    srl:
      kind: srl
      image: srlinux:20.6.3-145
      license: license.key
      config: test-srl-config.json
  links:
    - endpoints: ["srl:e1-1", "host:srl_e1-1"]
```