### PR TITLE
added capability to add interfaces to running containers

### DIFF
--- a/clab/docker.go
+++ b/clab/docker.go
@@ -221,6 +221,7 @@ func (c *CLab) CreateContainer(ctx context.Context, node *Node) (err error) {
 	return linkContainerNS(node.NSPath, node.LongName)
 }
 
+// GetNSPath inspects a container by its name/id and returns an netns path using the pid of a container
 func (c *CLab) GetNSPath(ctx context.Context, containerId string) (string, error) {
 	nctx, cancelFn := context.WithTimeout(ctx, c.timeout)
 	defer cancelFn()

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -113,6 +113,9 @@ func parseVethEndpoint(s string) (*vethEndpoint, error) {
 	switch len(arr) {
 	case 2:
 		ve.kind = "container"
+		if arr[0] == "host" {
+			ve.kind = "host"
+		}
 		ve.node = arr[0]
 		ve.iface = arr[1]
 	case 3:

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/srl-wim/container-lab/clab"
+)
+
+var AEnd = ""
+var BEnd = ""
+var Mtu = 1500
+
+func init() {
+	toolsCmd.AddCommand(vethCmd)
+	vethCmd.AddCommand(vethCreateCmd)
+	vethCreateCmd.Flags().StringVarP(&AEnd, "aend", "a", "", "<name of container1>:<interface name>")
+	vethCreateCmd.Flags().StringVarP(&BEnd, "bend", "b", "", "<name of container2>:<interface name>")
+	vethCreateCmd.Flags().IntVarP(&Mtu, "mtu", "m", Mtu, "MTU of the link")
+}
+
+var vethCmd = &cobra.Command{
+	Use:   "veth",
+	Short: "veth operations",
+}
+
+var vethCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "On-the-fly create a veth pair and attach it to the specified namespaces",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		opts := []clab.ClabOption{
+			clab.WithDebug(debug),
+			clab.WithTimeout(timeout),
+			clab.WithEnvDockerClient(),
+		}
+		c := clab.NewContainerLab(opts...)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var aEndCif containerInterface
+		var bEndCif containerInterface
+
+		if aEndCif, err = checkContainerInterfaceRef(AEnd); err != nil {
+			return err
+		}
+		if bEndCif, err = checkContainerInterfaceRef(BEnd); err != nil {
+			return err
+		}
+
+		aEndNode := new(clab.Node)
+		aEndNode.LongName = aEndCif.container
+		aEndNode.ShortName = aEndCif.container
+
+		bEndNode := new(clab.Node)
+		bEndNode.LongName = bEndCif.container
+		bEndNode.ShortName = bEndCif.container
+
+		nsPathA, err := c.GetNSPath(ctx, aEndNode.LongName)
+		if err != nil {
+			return err
+		}
+		nsPathB, err := c.GetNSPath(ctx, bEndNode.LongName)
+		if err != nil {
+			return err
+		}
+
+		aEndNode.NSPath = nsPathA
+		bEndNode.NSPath = nsPathB
+
+		endpointA := clab.Endpoint{
+			Node:         aEndNode,
+			EndpointName: aEndCif.iface,
+		}
+		endpointB := clab.Endpoint{
+			Node:         bEndNode,
+			EndpointName: bEndCif.iface,
+		}
+
+		link := new(clab.Link)
+		link.A = &endpointA
+		link.B = &endpointB
+		link.MTU = Mtu
+
+		if err := c.CreateVirtualWiring(link); err != nil {
+			return err
+		}
+		log.Info("veth pair successfully created!")
+		return nil
+	},
+}
+
+func checkContainerInterfaceRef(s string) (containerInterface, error) {
+	cif := *new(containerInterface)
+	arr := strings.Split(s, ":")
+	if len(arr) != 2 {
+		return cif, errors.New("malformed container interface reference")
+	}
+	cif.container = arr[0]
+	cif.iface = arr[1]
+
+	return cif, nil
+}
+
+type containerInterface struct {
+	container string
+	iface     string
+}

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -18,8 +18,8 @@ var MTU = 65000
 func init() {
 	toolsCmd.AddCommand(vethCmd)
 	vethCmd.AddCommand(vethCreateCmd)
-	vethCreateCmd.Flags().StringVarP(&AEnd, "a-end", "a", "", "veth endpoint A in the format of <containerA-name>:<interface-name> or <endpointA-type>:<endpoint-name>:<interface-name>")
-	vethCreateCmd.Flags().StringVarP(&BEnd, "b-end", "b", "", "veth endpoint B in the format of <containerB-name>:<interface-name> or <endpointB-type>:<endpoint-name>:<interface-name>")
+	vethCreateCmd.Flags().StringVarP(&AEnd, "a-endpoint", "a", "", "veth endpoint A in the format of <containerA-name>:<interface-name> or <endpointA-type>:<endpoint-name>:<interface-name>")
+	vethCreateCmd.Flags().StringVarP(&BEnd, "b-endpoint", "b", "", "veth endpoint B in the format of <containerB-name>:<interface-name> or <endpointB-type>:<endpoint-name>:<interface-name>")
 	vethCreateCmd.Flags().IntVarP(&MTU, "mtu", "m", MTU, "link MTU")
 }
 

--- a/cmd/tools_veth.go
+++ b/cmd/tools_veth.go
@@ -57,12 +57,14 @@ var vethCreateCmd = &cobra.Command{
 			LongName:  vethAEndpoint.node,
 			ShortName: vethAEndpoint.node,
 			Kind:      vethAEndpoint.kind,
+			NSPath:    "__host", // NSPath defaults to __host to make attachment to host. For attachment to containers the NSPath will be overwritten
 		}
 
 		bNode := &clab.Node{
 			LongName:  vethBEndpoint.node,
 			ShortName: vethBEndpoint.node,
 			Kind:      vethBEndpoint.kind,
+			NSPath:    "__host",
 		}
 
 		if aNode.Kind == "container" {

--- a/docs/cmd/tools/veth/create.md
+++ b/docs/cmd/tools/veth/create.md
@@ -1,0 +1,51 @@
+# vEth create
+### Description
+
+The `create` sub-command under the `tools veth` command creates a vEth interface between the following combination of nodes:
+
+1. container <-> container
+2. container <-> linux bridge
+3. container <-> ovs bridge
+4. container <-> host
+
+To specify the both endpoints of the veth interface pair the following two notations are used:
+
+1. two elements notation: `<node-name>:<interface-name>`
+    this notation is used for `container <-> container` or `container <-> host` attachments.
+2. three elements notation: `<kind>:<node-name>:<interface-name>`
+    this notation is used for `container <-> bridge` and `container <-> ovs-bridge` attachments
+
+Check out [examples](#examples) to see how these notations are used.
+
+### Usage
+
+`containerlab tools veth create [local-flags]`
+
+### Flags
+
+#### a-endpoint
+vEth interface endpoint A is set with `--a-endpoint | -a` flag.
+
+#### b-endpoint
+vEth interface endpoint B is set with `--b-endpoint | -b` flag.
+
+#### mtu
+vEth interface MTU is set to `65000` by default, and can be changed with `--mtu | -m` flag.
+
+### Examples
+
+```bash
+# create veth interface between containers clab-demo-node1 and clab-demo-node2
+# both ends of veth pair will be named `eth1`
+containerlab tools veth create -a clab-demo-node1:eth1 -b clab-demo-node2:eth1
+
+# create veth interface between container clab-demo-node1 and linux bridge br-1
+containerlab tools veth create -a clab-demo-node1:eth1 -b bridge:br-1:br-eth1
+
+# create veth interface between container clab-demo-node1 and OVS bridge ovsbr-1
+containerlab tools veth create -a clab-demo-node1:eth1 -b ovs-bridge:ovsbr-1:br-eth1
+
+# create veth interface between container clab-demo-node1 and host
+# note that a special node-name `host` is reserved to indicate that attachment is destined for container host system
+containerlab tools veth create -a clab-demo-node1:eth1 -b host:veth-eth1
+```

--- a/docs/cmd/tools/vxlan/create.md
+++ b/docs/cmd/tools/vxlan/create.md
@@ -2,7 +2,7 @@
 
 ### Description
 
-The `create` sub-command under the `tools vxlan` command creates a VxLAN inteface and sets `tc` rules to redirect traffic to/from a specified interface available in root namespace of a container host.
+The `create` sub-command under the `tools vxlan` command creates a VxLAN interface and sets `tc` rules to redirect traffic to/from a specified interface available in root namespace of a container host.
 
 This combination of a VxLAN interface and `tc` rules make possible to transparently connect lab nodes running on different VMs/hosts.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,8 @@ nav:
       - graph: cmd/graph.md
       - tools:
           - disable-tx-offload: cmd/tools/disable-tx-offload.md
+          - veth:
+              - create: cmd/tools/veth/create.md
           - vxlan:
               - create: cmd/tools/vxlan/create.md
               - delete: cmd/tools/vxlan/delete.md


### PR DESCRIPTION
This is a draft implementation for #252.

Issue the following to add a veth pair between wan1 and wan2.
`./containerlab tools connect containers  -t lab-examples/srl03/srl03.yml -a wan1:intf1 -b wan2:intf2 -m 1500`

Please have a look and provide feedback.
Cheers

close #252